### PR TITLE
feat(Event): metadata filter

### DIFF
--- a/src/routes/event.js
+++ b/src/routes/event.js
@@ -29,7 +29,8 @@ function init (server, { middlewares, helpers } = {}) {
       'objectType',
       'objectId',
       'emitter',
-      'emitterId'
+      'emitterId',
+      'metadata',
     ]
 
     const payload = _.pick(req.query, fields)

--- a/src/services/document.js
+++ b/src/services/document.js
@@ -410,9 +410,8 @@ function start ({ communication }) {
         },
         data: {
           value: data,
-          query: (queryBuilder, data) => {
-            queryBuilder.whereRaw('??::jsonb @> ?::jsonb', ['data', data])
-          }
+          dbField: 'data',
+          query: 'jsonSupersetOf'
         }
       },
       paginationActive: true,

--- a/src/services/event.js
+++ b/src/services/event.js
@@ -33,7 +33,8 @@ function start ({ communication }) {
       objectType,
       objectId,
       emitter,
-      emitterId
+      emitterId,
+      metadata
     } = req
 
     const queryBuilder = Event.query()
@@ -80,6 +81,11 @@ function start ({ communication }) {
           transformValue: 'array',
           query: 'inList'
         },
+        metadata: {
+          value: metadata,
+          dbField: 'metadata',
+          query: 'jsonSupersetOf'
+        }
       },
       paginationActive: true,
       paginationConfig: {

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -31,7 +31,8 @@ schemas['2019-05-20'].list = {
     objectType: [Joi.string(), Joi.array().unique().items(Joi.string())],
     objectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
     emitter: Joi.string().valid('core', 'custom', 'task'),
-    emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())]
+    emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    metadata: Joi.object().unknown()
   })
 }
 schemas['2019-05-20'].read = {

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -987,7 +987,12 @@ module.exports = {
       parentId: null,
       emitter: 'custom',
       emitterId: 'random',
-      metadata: {}
+      metadata: {
+        nested: {
+          object: true,
+          string: 'true'
+        }
+      }
     }),
 
     createModel({
@@ -1002,7 +1007,14 @@ module.exports = {
       parentId: null,
       emitter: 'custom',
       emitterId: 'Delorean',
-      metadata: {}
+      metadata: {
+        someTags: ['Doc', 'Brown'],
+        name: 'DMC-12',
+        nested: {
+          object: true,
+          string: 'true'
+        }
+      }
     })
   ],
 

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -616,6 +616,19 @@ test('list documents with data object filters', async (t) => {
   t.is(_.get(doc.data, 'tags.timesSeen'), 10)
   t.true(Array.isArray(_.get(doc.data, 'tags.heroes')))
   t.true(doc.data.tags.heroes.includes('Sheeta'))
+
+  const { body: noHit } = await request(t.context.serverUrl)
+    .get(`/documents?type=movie&data=${encode({
+      tags: {
+        awesome: true,
+        timesSeen: 10,
+        heroes: ['Unknown']
+      }
+    })}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  t.is(noHit.results.length, 0)
 })
 
 test('list documents with label filter', async (t) => {


### PR DESCRIPTION
List query can filter Events of which `metadata`
is a superset of passed object.

Sharing existing logic with Document API.