### PR TITLE
refactor(routes)!: move route flags to route objects

### DIFF
--- a/plugins/stripe/index.js
+++ b/plugins/stripe/index.js
@@ -5,8 +5,4 @@ module.exports = {
 
   routes: require('./routes'),
   versions: require('./versions'),
-
-  noApiKeyRoutes: [
-    { startsWith: '/providers/stripe/webhooks/' }
-  ]
 }

--- a/plugins/stripe/routes/stripe.js
+++ b/plugins/stripe/routes/stripe.js
@@ -149,7 +149,8 @@ function init (server, { middlewares, helpers } = {}) {
 
   server.post({
     name: 'stripe.webhooks.subscription',
-    path: '/providers/stripe/webhooks/:key/subscriptions'
+    path: '/providers/stripe/webhooks/:key/subscriptions',
+    optionalApiKey: true
   }, wrapAction(async (req, res) => {
     const {
       key

--- a/plugins/stripe/services/stripe.js
+++ b/plugins/stripe/services/stripe.js
@@ -374,8 +374,7 @@ module.exports = function createService (deps) {
     } = req
 
     const privateConfig = await configRequester.communicate(req)({
-      type: 'read',
-      _matchedPermissions: { 'config:read:all': true },
+      type: '_getConfig',
       access: 'private'
     })
 
@@ -449,8 +448,7 @@ module.exports = function createService (deps) {
     }
 
     const privateConfig = await configRequester.communicate(req)({
-      type: 'read',
-      _matchedPermissions: { 'config:read:all': true },
+      type: '_getConfig',
       access: 'private'
     })
 


### PR DESCRIPTION
instead of patching whole server with `noApiKeyRoutes`/`manualAuthRoutes`.
This makes route flags safer and more explicit.
Rename noApiKey flag to optionalApiKey.