### PR TITLE
Aggregations

### DIFF
--- a/plugins/serverTooling.js
+++ b/plugins/serverTooling.js
@@ -17,6 +17,7 @@ const versions = require('../src/versions')
 const time = require('../src/util/time')
 const encoding = require('../src/util/encoding')
 const validation = require('../src/util/validation')
+const math = require('../src/util/math')
 
 module.exports = {
   permissions,
@@ -35,6 +36,7 @@ module.exports = {
   utils: {
     time,
     encoding,
-    validation
+    validation,
+    math
   }
 }

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -123,6 +123,7 @@ const coreListObjectPermissions = [
   {
     object: 'event',
     actions: [
+      'stats:all',
       'list:all',
       'read:all',
       'create:all'

--- a/src/routes/event.js
+++ b/src/routes/event.js
@@ -12,6 +12,45 @@ function init (server, { middlewares, helpers } = {}) {
   } = helpers
 
   server.get({
+    name: 'event.getStats',
+    path: '/events/stats'
+  }, checkPermissions([
+    'event:stats:all'
+  ]), wrapAction(async (req, res) => {
+    const fields = [
+      'orderBy',
+      'order',
+      'page',
+      'nbResultsPerPage',
+
+      'field',
+      'groupBy',
+      'avgPrecision',
+
+      'id',
+      // 'type' // parsing manually below to avoid conflict with côte requester 'type'
+      'createdDate',
+      'objectType',
+      'objectId',
+      'emitter',
+      'emitterId',
+      'metadata',
+    ]
+
+    const payload = _.pick(req.query, fields)
+
+    let params = populateRequesterParams(req)({
+      type: 'getStats'
+    })
+
+    params = Object.assign({}, params, payload)
+
+    if (req.query) params.eventType = req.query.type
+
+    return requester.send(params)
+  }))
+
+  server.get({
     name: 'event.list',
     path: '/events'
   }, checkPermissions([

--- a/src/routes/event.js
+++ b/src/routes/event.js
@@ -34,6 +34,7 @@ function init (server, { middlewares, helpers } = {}) {
       'objectId',
       'emitter',
       'emitterId',
+      'object',
       'metadata',
     ]
 
@@ -69,6 +70,7 @@ function init (server, { middlewares, helpers } = {}) {
       'objectId',
       'emitter',
       'emitterId',
+      'object',
       'metadata',
     ]
 

--- a/src/services/event.js
+++ b/src/services/event.js
@@ -38,6 +38,7 @@ function start ({ communication }) {
       objectId,
       emitter,
       emitterId,
+      object,
       metadata
     } = req
 
@@ -89,6 +90,11 @@ function start ({ communication }) {
           transformValue: 'array',
           query: 'inList'
         },
+        object: {
+          value: object,
+          dbField: 'object',
+          query: 'jsonSupersetOf'
+        },
         metadata: {
           value: metadata,
           dbField: 'metadata',
@@ -127,6 +133,7 @@ function start ({ communication }) {
       objectId,
       emitter,
       emitterId,
+      object,
       metadata
     } = req
 
@@ -173,6 +180,11 @@ function start ({ communication }) {
           value: emitterId,
           transformValue: 'array',
           query: 'inList'
+        },
+        object: {
+          value: object,
+          dbField: 'object',
+          query: 'jsonSupersetOf'
         },
         metadata: {
           value: metadata,

--- a/src/services/event.js
+++ b/src/services/event.js
@@ -1,7 +1,7 @@
 const createError = require('http-errors')
 const { getModels, getModelInfo } = require('../models')
 
-const { performListQuery } = require('../util/listQueryBuilder')
+const { performListQuery, performAggregationQuery } = require('../util/listQueryBuilder')
 
 let responder
 
@@ -13,6 +13,99 @@ function start ({ communication }) {
   responder = getResponder({
     name: 'Event Responder',
     key: 'event'
+  })
+
+  responder.on('getStats', async (req) => {
+    const platformId = req.platformId
+    const env = req.env
+    const { Event } = await getModels({ platformId, env })
+
+    const {
+      orderBy,
+      order,
+
+      page,
+      nbResultsPerPage,
+
+      field,
+      groupBy,
+      avgPrecision,
+
+      id,
+      createdDate,
+      eventType: type,
+      objectType,
+      objectId,
+      emitter,
+      emitterId,
+      metadata
+    } = req
+
+    const queryBuilder = Event.knex()
+
+    const paginationMeta = await performAggregationQuery({
+      queryBuilder,
+      groupBy,
+      field,
+      schema: Event.defaultSchema,
+      avgPrecision,
+      filters: {
+        ids: {
+          dbField: 'id',
+          value: id,
+          transformValue: 'array',
+          query: 'inList'
+        },
+        createdDate: {
+          dbField: 'createdDate',
+          value: createdDate,
+          query: 'range'
+        },
+        types: {
+          dbField: 'type',
+          value: type,
+          transformValue: 'array',
+          query: 'inList'
+        },
+        objectTypes: {
+          dbField: 'objectType',
+          value: objectType,
+          transformValue: 'array',
+          query: 'inList'
+        },
+        objectIds: {
+          dbField: 'objectId',
+          value: objectId,
+          transformValue: 'array',
+          query: 'inList'
+        },
+        emitter: {
+          dbField: 'emitter',
+          value: emitter
+        },
+        emitterIds: {
+          dbField: 'emitterId',
+          value: emitterId,
+          transformValue: 'array',
+          query: 'inList'
+        },
+        metadata: {
+          value: metadata,
+          dbField: 'metadata',
+          query: 'jsonSupersetOf'
+        }
+      },
+      paginationConfig: {
+        page,
+        nbResultsPerPage
+      },
+      orderConfig: {
+        orderBy,
+        order
+      }
+    })
+
+    return paginationMeta
   })
 
   responder.on('list', async (req) => {

--- a/src/util/listQueryBuilder.js
+++ b/src/util/listQueryBuilder.js
@@ -3,6 +3,7 @@ const createError = require('http-errors')
 
 const { Joi } = require('./validation')
 const { parseArrayValues, getPaginationMeta } = require('./list')
+const { roundDecimal } = require('./math')
 
 const filtersSchema = Joi.object().pattern(
   Joi.string(),
@@ -418,7 +419,7 @@ async function performAggregationQuery ({
     delete clonedResult.groupByField
 
     if (clonedResult.count) clonedResult.count = parseInt(clonedResult.count, 10)
-    if (_.isNumber(clonedResult.avg)) clonedResult.avg = getFloatWithPrecision(clonedResult.avg, avgPrecision)
+    if (_.isNumber(clonedResult.avg)) clonedResult.avg = roundDecimal(clonedResult.avg, avgPrecision)
 
     const operators = ['avg', 'sum', 'min', 'max']
     operators.forEach(op => {
@@ -428,10 +429,6 @@ async function performAggregationQuery ({
     return clonedResult
   })
   return paginationMeta
-}
-
-function getFloatWithPrecision (number, precision) {
-  return parseFloat(number.toFixed(precision))
 }
 
 /**

--- a/src/util/math.js
+++ b/src/util/math.js
@@ -1,0 +1,10 @@
+// Do not use "classic" rounding method (e.g `Math.round(8.325 * 100) / 100 === 8.32`)
+// Instead use a more accurate rounding with exponential notation (e.g `Number(Math.round(8.325 + 'e2') + 'e-2') === 8.33`)
+// https://www.jacklmoore.com/notes/rounding-in-javascript/
+function roundDecimal (number, precision, customFn = Math.round) {
+  return Number(customFn(`${number}e${precision}`) + `e-${precision}`)
+}
+
+module.exports = {
+  roundDecimal
+}

--- a/src/util/pricing.js
+++ b/src/util/pricing.js
@@ -14,14 +14,13 @@ module.exports = {
 const _ = require('lodash')
 
 const {
+  roundDecimal
+} = require('./math')
+
+const {
   getCurrencyDecimal,
   isValidCurrency
 } = require('./currency')
-
-function roundDecimal (num, decimal, roundingFn = Math.round) {
-  const divisor = Math.pow(10, decimal)
-  return roundingFn(num * divisor) / divisor
-}
 
 function roundPrice (price) {
   if (typeof price === 'string') {

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -10,10 +10,56 @@ const orderByFields = [
 
 const schemas = {}
 
+const getObjectSchema = (name) => Joi.string().regex(new RegExp(`^${name}\\.\\w+$`))
+
+const groupBySchema = Joi.alternatives().try(
+  Joi.string().valid(
+    'type',
+    'objectType',
+    'objectId',
+    'parentId',
+    'emitter',
+    'emitterId'
+  ),
+  getObjectSchema('object'),
+  getObjectSchema('metadata')
+)
+
+const fieldSchema = Joi.alternatives().try(
+  getObjectSchema('object'),
+  getObjectSchema('metadata')
+)
+
 // ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
+schemas['2019-05-20'].getStats = {
+  query: Joi.object().keys({
+    // order
+    orderBy: Joi.string().valid('avg', 'count', 'sum', 'min', 'max').default('count'),
+    order: Joi.string().valid('asc', 'desc').default('desc'),
+
+    // pagination
+    page: Joi.number().integer().min(1).default(1),
+    nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
+
+    // aggregation
+    groupBy: groupBySchema.required(),
+    field: fieldSchema,
+    avgPrecision: Joi.number().integer().min(0).default(2),
+
+    // filters
+    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    createdDate: getRangeFilter(Joi.string().isoDate()),
+    type: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    objectType: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    objectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    emitter: Joi.string().valid('core', 'custom', 'task'),
+    emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    metadata: Joi.object().unknown()
+  })
+}
 schemas['2019-05-20'].list = {
   query: Joi.object().keys({
     // order
@@ -49,6 +95,10 @@ schemas['2019-05-20'].create = {
 
 const validationVersions = {
   '2019-05-20': [
+    {
+      target: 'event.getStats',
+      schema: schemas['2019-05-20'].getStats
+    },
     {
       target: 'event.list',
       schema: schemas['2019-05-20'].list

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -10,7 +10,8 @@ const orderByFields = [
 
 const schemas = {}
 
-const getObjectSchema = (name) => Joi.string().regex(new RegExp(`^${name}\\.\\w+$`))
+// match string value like 'a.b.c' or 'a[0].b.c[2]'
+const getObjectSchema = (name) => Joi.string().regex(new RegExp(`^${name}((\\[(\\d+)\\]|\\.\\w+)*)$`))
 
 const groupBySchema = Joi.alternatives().try(
   Joi.string().valid(
@@ -50,13 +51,13 @@ schemas['2019-05-20'].getStats = {
     avgPrecision: Joi.number().integer().min(0).default(2),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: Joi.array().unique().items(Joi.string()).single(),
     createdDate: getRangeFilter(Joi.string().isoDate()),
-    type: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    objectType: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    objectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    type: Joi.array().unique().items(Joi.string()).single(),
+    objectType: Joi.array().unique().items(Joi.string()).single(),
+    objectId: Joi.array().unique().items(Joi.string()).single(),
     emitter: Joi.string().valid('core', 'custom', 'task'),
-    emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    emitterId: Joi.array().unique().items(Joi.string()).single(),
     object: Joi.object().unknown(),
     metadata: Joi.object().unknown()
   })

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -11,7 +11,10 @@ const orderByFields = [
 const schemas = {}
 
 // match string value like 'a.b.c' or 'a[0].b.c[2]'
-const getObjectSchema = (name) => Joi.string().regex(new RegExp(`^${name}((\\[(\\d+)\\]|\\.\\w+)*)$`))
+const getObjectSchema = (name) => Joi.string()
+  .pattern(new RegExp(`^${name}((\\[(\\d+)\\]|\\.\\w+)*)$`), {
+    name: `accessor string like ${name}.nested.arr[1]`
+  })
 
 const groupBySchema = Joi.alternatives().try(
   Joi.string().valid(

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -57,6 +57,7 @@ schemas['2019-05-20'].getStats = {
     objectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
     emitter: Joi.string().valid('core', 'custom', 'task'),
     emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    object: Joi.object().unknown(),
     metadata: Joi.object().unknown()
   })
 }
@@ -78,6 +79,7 @@ schemas['2019-05-20'].list = {
     objectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
     emitter: Joi.string().valid('core', 'custom', 'task'),
     emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    object: Joi.object().unknown(),
     metadata: Joi.object().unknown()
   })
 }

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -165,7 +165,18 @@ const validatedTransaction1 = {
   completedDate: null,
   cancelledDate: null,
   cancellationReason: null,
-  metadata: {},
+  metadata: {
+    someObject: {
+      someValue: 10,
+      arrayValues: [{
+        deepArrayValue: [10]
+      }]
+    },
+    otherObject: {
+      status: 'validated',
+      arrayStatuses: ['validated']
+    }
+  },
   platformData: {}
 }
 
@@ -201,7 +212,18 @@ const validatedTransaction2 = {
   completedDate: null,
   cancelledDate: null,
   cancellationReason: null,
-  metadata: {},
+  metadata: {
+    someObject: {
+      someValue: 2,
+      arrayValues: [{
+        deepArrayValue: [2]
+      }]
+    },
+    otherObject: {
+      status: 'validated',
+      arrayStatuses: ['validated']
+    }
+  },
   platformData: {}
 }
 
@@ -236,7 +258,18 @@ const paidTransaction = {
   completedDate: null,
   cancelledDate: null,
   cancellationReason: null,
-  metadata: {},
+  metadata: {
+    someObject: {
+      someValue: 3,
+      arrayValues: [{
+        deepArrayValue: [3]
+      }]
+    },
+    otherObject: {
+      status: 'pending-acceptance',
+      arrayStatuses: ['pending-acceptance']
+    }
+  },
   platformData: {}
 }
 
@@ -271,7 +304,18 @@ const acceptedTransaction = {
   completedDate: null,
   cancelledDate: null,
   cancellationReason: null,
-  metadata: {},
+  metadata: {
+    someObject: {
+      someValue: 5,
+      arrayValues: [{
+        deepArrayValue: [5]
+      }]
+    },
+    otherObject: {
+      status: 'accepted',
+      arrayStatuses: ['accepted']
+    }
+  },
   platformData: {}
 }
 

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -133,6 +133,148 @@ const assetType2 = {
   platformData: {}
 }
 
+const validatedTransaction1 = {
+  id: 'trn_Wm1fQps1I3a1gJYz2I3a',
+  createdDate: now,
+  updatedDate: now,
+  assetId: asset1.id,
+  assetSnapshot: asset1,
+  assetTypeId: assetType1.id,
+  assetType: assetType1,
+  status: 'validated',
+  statusHistory: [
+    { status: 'validated', date: now },
+    { status: 'pending-acceptance', date: now },
+    { status: 'draft', date: now }
+  ],
+  ownerId: 'usr_QVQfQps1I3a1gJYz2I3a',
+  takerId: 'usr_Y0tfQps1I3a1gJYz2I3a',
+  quantity: 1,
+  startDate: computeDate(now, '1 days'),
+  endDate: computeDate(now, '2 days'),
+  duration: { d: 1 },
+  timeUnit: 'd',
+  unitPrice: 100,
+  value: 100,
+  ownerAmount: 95,
+  takerAmount: 118,
+  platformAmount: 23,
+  ownerFees: 5,
+  takerFees: 18,
+  currency: 'USD',
+  completedDate: null,
+  cancelledDate: null,
+  cancellationReason: null,
+  metadata: {},
+  platformData: {}
+}
+
+const validatedTransaction2 = {
+  id: 'trn_VHgfQps1I3a1gJYz2I3a',
+  createdDate: now,
+  updatedDate: now,
+  assetId: asset1.id,
+  assetSnapshot: asset1,
+  assetTypeId: assetType1.id,
+  assetType: assetType1,
+  status: 'validated',
+  statusHistory: [
+    { status: 'validated', date: now },
+    { status: 'pending-acceptance', date: now },
+    { status: 'draft', date: now }
+  ],
+  ownerId: 'usr_QVQfQps1I3a1gJYz2I3a',
+  takerId: 'usr_Y0tfQps1I3a1gJYz2I3a',
+  quantity: 1,
+  startDate: computeDate(now, '5 days'),
+  endDate: computeDate(now, '7 days'),
+  duration: { d: 2 },
+  timeUnit: 'd',
+  unitPrice: 100,
+  value: 200,
+  ownerAmount: 190,
+  takerAmount: 236,
+  platformAmount: 46,
+  ownerFees: 10,
+  takerFees: 36,
+  currency: 'USD',
+  completedDate: null,
+  cancelledDate: null,
+  cancellationReason: null,
+  metadata: {},
+  platformData: {}
+}
+
+const paidTransaction = {
+  id: 'trn_RjhfQps1I3a1gJYz2I3a',
+  createdDate: now,
+  updatedDate: now,
+  assetId: asset1.id,
+  assetSnapshot: asset1,
+  assetTypeId: assetType1.id,
+  assetType: assetType1,
+  status: 'pending-acceptance',
+  statusHistory: [
+    { status: 'pending-acceptance', date: now },
+    { status: 'draft', date: now }
+  ],
+  ownerId: 'fd7b4ea9-a899-4dba-b9b0-ef8537a70efe',
+  takerId: 'ff4bf0dd-b1d9-49c9-8c61-3e3baa04181c',
+  quantity: 1,
+  startDate: computeDate(now, '25 days'),
+  endDate: computeDate(now, '30 days'),
+  duration: { d: 5 },
+  timeUnit: 'd',
+  unitPrice: 100,
+  value: 500,
+  ownerAmount: 475,
+  takerAmount: 589,
+  platformAmount: 114,
+  ownerFees: 25,
+  takerFees: 89,
+  currency: 'USD',
+  completedDate: null,
+  cancelledDate: null,
+  cancellationReason: null,
+  metadata: {},
+  platformData: {}
+}
+
+const acceptedTransaction = {
+  id: 'trn_ZVZfQps1I3a1gJYz2I3a',
+  createdDate: now,
+  updatedDate: now,
+  assetId: asset1.id,
+  assetSnapshot: asset1,
+  assetTypeId: assetType1.id,
+  assetType: assetType1,
+  status: 'accepted',
+  statusHistory: [
+    { status: 'accepted', date: now },
+    { status: 'draft', date: now }
+  ],
+  ownerId: 'fd7b4ea9-a899-4dba-b9b0-ef8537a70efe',
+  takerId: 'ff4bf0dd-b1d9-49c9-8c61-3e3baa04181c',
+  quantity: 1,
+  startDate: computeDate(now, '7 days'),
+  endDate: computeDate(now, '12 days'),
+  duration: { d: 5 },
+  timeUnit: 'd',
+  unitPrice: 100,
+  value: 500,
+  ownerAmount: 475,
+  takerAmount: 589,
+  platformAmount: 114,
+  ownerFees: 25,
+  takerFees: 89,
+  currency: 'USD',
+  completedDate: null,
+  cancelledDate: null,
+  cancellationReason: null,
+  metadata: {},
+  platformData: {}
+}
+
 module.exports = {
 
   apiKey: [
@@ -1015,7 +1157,189 @@ module.exports = {
           string: 'true'
         }
       }
-    })
+    }),
+
+    createModel({
+      id: 'evt_EYtSSge1EZX1iZboZEZX',
+      createdDate: now,
+      type: 'transaction__created',
+      objectType: 'transaction',
+      objectId: validatedTransaction1.id,
+      object: Object.assign({}, validatedTransaction1, {
+        status: 'draft',
+        statusHistory: validatedTransaction1.statusHistory
+          .filter(status => status === 'draft')
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_1OX9pme1s7z1jDAKUs7z',
+      createdDate: now,
+      type: 'transaction__status_changed',
+      objectType: 'transaction',
+      objectId: validatedTransaction1.id,
+      object: Object.assign({}, validatedTransaction1, {
+        status: 'pending-acceptance',
+        statusHistory: validatedTransaction1.statusHistory
+          .filter(status => ['draft', 'pending-acceptance'].includes(status))
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_IFmuYue1w2s1jH5Daw2s',
+      createdDate: now,
+      type: 'transaction__status_changed',
+      objectType: 'transaction',
+      objectId: validatedTransaction1.id,
+      object: validatedTransaction1,
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_ujdqLfe1q0i1jB33jq0i',
+      createdDate: now,
+      type: 'transaction__created',
+      objectType: 'transaction',
+      objectId: validatedTransaction2.id,
+      object: Object.assign({}, validatedTransaction2, {
+        status: 'draft',
+        statusHistory: validatedTransaction2.statusHistory
+          .filter(status => status === 'draft')
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_dDbZfEe1sxw1jE0Kusxw',
+      createdDate: now,
+      type: 'transaction__status_changed',
+      objectType: 'transaction',
+      objectId: validatedTransaction2.id,
+      object: Object.assign({}, validatedTransaction2, {
+        status: 'pending-acceptance',
+        statusHistory: validatedTransaction2.statusHistory
+          .filter(status => ['draft', 'pending-acceptance'].includes(status))
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_FOCH8le1GgB1ibiWuGgB',
+      createdDate: now,
+      type: 'transaction__status_changed',
+      objectType: 'transaction',
+      objectId: validatedTransaction2.id,
+      object: validatedTransaction2,
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_rS0eIbe11GD1iMIZt1GD',
+      createdDate: now,
+      type: 'transaction__created',
+      objectType: 'transaction',
+      objectId: paidTransaction.id,
+      object: Object.assign({}, paidTransaction, {
+        status: 'draft',
+        statusHistory: paidTransaction.statusHistory
+          .filter(status => status === 'draft')
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_j5braLe1vv31jGxPyvv3',
+      createdDate: now,
+      type: 'transaction__status_changed',
+      objectType: 'transaction',
+      objectId: paidTransaction.id,
+      object: Object.assign({}, paidTransaction, {
+        status: 'pending-acceptance',
+        statusHistory: paidTransaction.statusHistory
+          .filter(status => ['draft', 'pending-acceptance'].includes(status))
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_0fB70Ie1Mt31ihvQRMt3',
+      createdDate: now,
+      type: 'transaction__created',
+      objectType: 'transaction',
+      objectId: acceptedTransaction.id,
+      object: Object.assign({}, acceptedTransaction, {
+        status: 'draft',
+        statusHistory: acceptedTransaction.statusHistory
+          .filter(status => status === 'draft')
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
+
+    createModel({
+      id: 'evt_o6onJ4e1dzz1iz2MWdzz',
+      createdDate: now,
+      type: 'transaction__status_changed',
+      objectType: 'transaction',
+      objectId: acceptedTransaction.id,
+      object: Object.assign({}, acceptedTransaction, {
+        status: 'accepted',
+        statusHistory: acceptedTransaction.statusHistory
+          .filter(status => ['draft', 'accepted'].includes(status))
+      }),
+      relatedObjectsIds: {},
+      apiVersion: '2019-05-20',
+      parentId: null,
+      emitter: 'core',
+      emitterId: null,
+      metadata: {}
+    }),
   ],
 
   entry: [
@@ -1889,76 +2213,10 @@ module.exports = {
     }),
 
     // transaction paid
-    createModel({
-      id: 'trn_RjhfQps1I3a1gJYz2I3a',
-      createdDate: now,
-      updatedDate: now,
-      assetId: asset1.id,
-      assetSnapshot: asset1,
-      assetTypeId: assetType1.id,
-      assetType: assetType1,
-      status: 'pending-acceptance',
-      statusHistory: [
-        { status: 'pending-acceptance', date: now },
-        { status: 'draft', date: now }
-      ],
-      ownerId: 'fd7b4ea9-a899-4dba-b9b0-ef8537a70efe',
-      takerId: 'ff4bf0dd-b1d9-49c9-8c61-3e3baa04181c',
-      quantity: 1,
-      startDate: computeDate(now, '25 days'),
-      endDate: computeDate(now, '30 days'),
-      duration: { d: 5 },
-      timeUnit: 'd',
-      unitPrice: 100,
-      value: 500,
-      ownerAmount: 475,
-      takerAmount: 589,
-      platformAmount: 114,
-      ownerFees: 25,
-      takerFees: 89,
-      currency: 'USD',
-      completedDate: null,
-      cancelledDate: null,
-      cancellationReason: null,
-      metadata: {},
-      platformData: {}
-    }),
+    createModel(paidTransaction),
 
     // transaction accepted
-    createModel({
-      id: 'trn_ZVZfQps1I3a1gJYz2I3a',
-      createdDate: now,
-      updatedDate: now,
-      assetId: asset1.id,
-      assetSnapshot: asset1,
-      assetTypeId: assetType1.id,
-      assetType: assetType1,
-      status: 'accepted',
-      statusHistory: [
-        { status: 'accepted', date: now },
-        { status: 'draft', date: now }
-      ],
-      ownerId: 'fd7b4ea9-a899-4dba-b9b0-ef8537a70efe',
-      takerId: 'ff4bf0dd-b1d9-49c9-8c61-3e3baa04181c',
-      quantity: 1,
-      startDate: computeDate(now, '7 days'),
-      endDate: computeDate(now, '12 days'),
-      duration: { d: 5 },
-      timeUnit: 'd',
-      unitPrice: 100,
-      value: 500,
-      ownerAmount: 475,
-      takerAmount: 589,
-      platformAmount: 114,
-      ownerFees: 25,
-      takerFees: 89,
-      currency: 'USD',
-      completedDate: null,
-      cancelledDate: null,
-      cancellationReason: null,
-      metadata: {},
-      platformData: {}
-    }),
+    createModel(acceptedTransaction),
 
     // transaction to cancel
     createModel({
@@ -1996,78 +2254,10 @@ module.exports = {
     }),
 
     // transaction paid and accepted
-    createModel({
-      id: 'trn_Wm1fQps1I3a1gJYz2I3a',
-      createdDate: now,
-      updatedDate: now,
-      assetId: asset1.id,
-      assetSnapshot: asset1,
-      assetTypeId: assetType1.id,
-      assetType: assetType1,
-      status: 'validated',
-      statusHistory: [
-        { status: 'validated', date: now },
-        { status: 'pending-acceptance', date: now },
-        { status: 'draft', date: now }
-      ],
-      ownerId: 'usr_QVQfQps1I3a1gJYz2I3a',
-      takerId: 'usr_Y0tfQps1I3a1gJYz2I3a',
-      quantity: 1,
-      startDate: computeDate(now, '1 days'),
-      endDate: computeDate(now, '2 days'),
-      duration: { d: 1 },
-      timeUnit: 'd',
-      unitPrice: 100,
-      value: 100,
-      ownerAmount: 95,
-      takerAmount: 118,
-      platformAmount: 23,
-      ownerFees: 5,
-      takerFees: 18,
-      currency: 'USD',
-      completedDate: null,
-      cancelledDate: null,
-      cancellationReason: null,
-      metadata: {},
-      platformData: {}
-    }),
+    createModel(validatedTransaction1),
 
     // transaction paid and accepted
-    createModel({
-      id: 'trn_VHgfQps1I3a1gJYz2I3a',
-      createdDate: now,
-      updatedDate: now,
-      assetId: asset1.id,
-      assetSnapshot: asset1,
-      assetTypeId: assetType1.id,
-      assetType: assetType1,
-      status: 'validated',
-      statusHistory: [
-        { status: 'validated', date: now },
-        { status: 'pending-acceptance', date: now },
-        { status: 'draft', date: now }
-      ],
-      ownerId: 'usr_QVQfQps1I3a1gJYz2I3a',
-      takerId: 'usr_Y0tfQps1I3a1gJYz2I3a',
-      quantity: 1,
-      startDate: computeDate(now, '5 days'),
-      endDate: computeDate(now, '7 days'),
-      duration: { d: 2 },
-      timeUnit: 'd',
-      unitPrice: 100,
-      value: 200,
-      ownerAmount: 190,
-      takerAmount: 236,
-      platformAmount: 46,
-      ownerFees: 10,
-      takerFees: 36,
-      currency: 'USD',
-      completedDate: null,
-      cancelledDate: null,
-      cancellationReason: null,
-      metadata: {},
-      platformData: {}
-    }),
+    createModel(validatedTransaction2),
 
     // transaction in Euro
     createModel({

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -486,6 +486,20 @@ test('get aggregated field stats with average rounded to integer', async (t) => 
   })
 })
 
+test('fails to get aggregated stats with non-number field', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+
+  const groupBy = 'authorId'
+  const field = 'data.title'
+
+  const { body: error } = await request(t.context.serverUrl)
+    .get(`/documents/stats?type=movie&groupBy=${groupBy}&field=${field}`)
+    .set(authorizationHeaders)
+    .expect(422)
+
+  t.true(error.message.includes(`Non-number value was found for field "${field}"`))
+})
+
 test('list documents', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:list:all'] })
 

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -6,6 +6,7 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
+const { checkStatsObject } = require('../../util')
 
 test.before(async (t) => {
   await before({ name: 'document' })(t)
@@ -15,234 +16,220 @@ test.before(async (t) => {
 test.after(after())
 
 test('get simple documents stats', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const result = await request(t.context.serverUrl)
-    .get('/documents/stats?type=movie&groupBy=data.director')
+  const groupBy = 'data.director'
+  const filters = 'type=movie'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-
-  obj.results.forEach(result => {
-    t.is(result.groupBy, 'data.director')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(result.sum, null)
-    t.is(result.avg, null)
-    t.is(result.min, null)
-    t.is(result.max, null)
-  })
-
-  // check order: count desc by default
-  let count
-  obj.results.forEach(result => {
-    if (typeof count === 'undefined') {
-      count = result.count
-    } else {
-      t.true(count >= result.count)
-    }
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    results: documents
   })
 })
 
 test('get aggregated field stats', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const result = await request(t.context.serverUrl)
-    .get('/documents/stats?type=movie&groupBy=data.director&field=data.score&orderBy=avg&order=asc')
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-
-  obj.results.forEach(result => {
-    t.is(result.groupBy, 'data.director')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(typeof result.sum, 'number')
-    t.is(typeof result.avg, 'number')
-    t.is(typeof result.min, 'number')
-    t.is(typeof result.max, 'number')
-    t.is(typeof result.ranking, 'undefined')
-    t.is(typeof result.lowestRanking, 'undefined')
-  })
-
-  // check order: avg asc
-  let avg
-  obj.results.forEach(result => {
-    if (typeof avg === 'undefined') {
-      avg = result.avg
-    } else {
-      t.true(avg <= result.avg)
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'undefined')
+      t.is(typeof result.lowestRanking, 'undefined')
     }
   })
 })
 
 test('get aggregated field stats by authorId and filter on an authorId', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const result = await request(t.context.serverUrl)
-    .get('/documents/stats?type=movie&groupBy=authorId&field=data.score&orderBy=avg&order=asc&authorId=user-external-id')
+  const groupBy = 'authorId'
+  const field = 'data.score'
+  const filters = 'type=movie&authorId=user-external-id'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-
-  obj.results.forEach(result => {
-    t.is(result.groupBy, 'authorId')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(typeof result.sum, 'number')
-    t.is(typeof result.avg, 'number')
-    t.is(typeof result.min, 'number')
-    t.is(typeof result.max, 'number')
-    t.is(typeof result.ranking, 'undefined')
-    t.is(typeof result.lowestRanking, 'undefined')
-  })
-
-  // check order: avg asc
-  let avg
-  obj.results.forEach(result => {
-    if (typeof avg === 'undefined') {
-      avg = result.avg
-    } else {
-      t.true(avg <= result.avg)
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'undefined')
+      t.is(typeof result.lowestRanking, 'undefined')
     }
   })
 })
 
 test('get aggregated field stats with ranking', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const result = await request(t.context.serverUrl)
-    .get('/documents/stats?type=movie&groupBy=data.director&field=data.score&orderBy=avg&order=asc&computeRanking=true')
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie&authorId=user-external-id'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-
-  obj.results.forEach(result => {
-    t.truthy(result.groupBy, 'data.director')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(typeof result.sum, 'number')
-    t.is(typeof result.avg, 'number')
-    t.is(typeof result.min, 'number')
-    t.is(typeof result.max, 'number')
-    t.is(typeof result.ranking, 'number')
-    t.is(typeof result.lowestRanking, 'number')
-
-    t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
-  })
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
 
   let ranking
-  let avg
-  obj.results.forEach(result => {
-    // check ranking order
-    if (typeof ranking === 'undefined') {
-      ranking = result.ranking
-    } else {
-      t.true(ranking < result.ranking)
-    }
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
 
-    // check order: avg asc
-    if (typeof avg === 'undefined') {
-      avg = result.avg
-    } else {
-      t.true(avg <= result.avg)
+      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+
+      // check ranking order
+      if (typeof ranking === 'undefined') {
+        ranking = result.ranking
+      } else {
+        t.true(ranking < result.ranking)
+      }
     }
   })
 })
 
 test('get aggregated field stats with ranking with specified label', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const queryParams = 'type=movie&groupBy=data.director&field=data.score&orderBy=avg&order=asc' +
-    '&computeRanking=true&label=source:imdb'
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie&label=source:imdb'
+  const orderBy = 'avg'
+  const order = 'asc'
 
-  const result = await request(t.context.serverUrl)
-    .get(`/documents/stats?${queryParams}`)
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-
-  obj.results.forEach(result => {
-    t.truthy(result.groupBy, 'data.director')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(typeof result.sum, 'number')
-    t.is(typeof result.avg, 'number')
-    t.is(typeof result.min, 'number')
-    t.is(typeof result.max, 'number')
-    t.is(typeof result.ranking, 'number')
-    t.is(typeof result.lowestRanking, 'number')
-
-    t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
-  })
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
 
   let ranking
-  let avg
-  obj.results.forEach(result => {
-    // check ranking order
-    if (typeof ranking === 'undefined') {
-      ranking = result.ranking
-    } else {
-      t.true(ranking < result.ranking)
-    }
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
 
-    // check order: avg asc
-    if (typeof avg === 'undefined') {
-      avg = result.avg
-    } else {
-      t.true(avg <= result.avg)
+      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+
+      // check ranking order
+      if (typeof ranking === 'undefined') {
+        ranking = result.ranking
+      } else {
+        t.true(ranking < result.ranking)
+      }
     }
   })
 
-  const queryParams2 = 'type=movie&groupBy=data.director&field=data.score&orderBy=avg&order=asc' +
-    '&computeRanking=true&label=source:random'
+  const filters2 = 'type=movie&label=source:random'
 
-  const result2 = await request(t.context.serverUrl)
-    .get(`/documents/stats?${queryParams2}`)
+  const { body: obj2 } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters2}&computeRanking=true`)
     .set(authorizationHeaders)
     .expect(200)
-
-  const obj2 = result2.body
 
   t.true(obj.results[0].avg !== obj2.results[0].avg)
 })
@@ -289,14 +276,25 @@ test('get aggregated field stats with ranking with wildcard label', async (t) =>
 })
 
 test('get aggregated field stats with ranking and postranking filter', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const beforeResult = await request(t.context.serverUrl)
-    .get('/documents/stats?type=movie&groupBy=data.director&field=data.score&orderBy=avg&order=asc&computeRanking=true')
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: beforeObj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const beforeObj = beforeResult.body
   const lowestRanking = beforeObj.nbResults
 
   const directorRanking = beforeObj.results.reduce((memo, result) => {
@@ -307,52 +305,60 @@ test('get aggregated field stats with ranking and postranking filter', async (t)
   }, null)
 
   // Now only filter on the director, ranking stats should not changed
-  const queryParams = 'type=movie&groupBy=data.director&field=data.score&orderBy=avg' +
-    '&order=asc&computeRanking=true&data[director]=Hayao+Miyazaki'
+  const filters2 = 'type=movie&data[director]=Hayao+Miyazaki'
 
-  const result = await request(t.context.serverUrl)
-    .get(`/documents/stats?${queryParams}`)
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters2}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters2}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.is(obj.nbResults, 1)
-  t.true(Array.isArray(obj.results))
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
 
-  obj.results.forEach(result => {
-    t.is(result.groupBy, 'data.director')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(typeof result.sum, 'number')
-    t.is(typeof result.avg, 'number')
-    t.is(typeof result.min, 'number')
-    t.is(typeof result.max, 'number')
-    t.is(typeof result.ranking, 'number')
-    t.is(typeof result.lowestRanking, 'number')
-
-    t.is(result.ranking, directorRanking)
-    t.is(result.lowestRanking, lowestRanking)
+      t.is(result.ranking, directorRanking)
+      t.is(result.lowestRanking, lowestRanking)
+    }
   })
 })
 
 test('get aggregated field stats with ranking and preranking filter', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
 
-  const queryParams = 'type=movie&groupBy=data.director&field=data.score&orderBy=avg' +
-    '&order=asc&computeRanking=true&data[composer]=Masaru+Sato'
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie&data[composer]=Masaru+Sato'
+  const orderBy = 'avg'
+  const order = 'asc'
 
-  const result = await request(t.context.serverUrl)
-    .get(`/documents/stats?${queryParams}`)
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
 
   t.true(typeof obj === 'object')
   t.true(typeof obj.nbResults === 'number')
@@ -361,16 +367,18 @@ test('get aggregated field stats with ranking and preranking filter', async (t) 
   t.true(typeof obj.nbResultsPerPage === 'number')
   t.true(Array.isArray(obj.results))
 
-  obj.results.forEach(result => {
-    t.is(result.groupBy, 'data.director')
-    t.truthy(result.groupByValue)
-    t.is(typeof result.count, 'number')
-    t.is(typeof result.sum, 'number')
-    t.is(typeof result.avg, 'number')
-    t.is(typeof result.min, 'number')
-    t.is(typeof result.max, 'number')
-    t.is(typeof result.ranking, 'number')
-    t.is(typeof result.lowestRanking, 'number')
+  checkStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
+    }
   })
 })
 

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -7,6 +7,7 @@ const _ = require('lodash')
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
 const { computeDate } = require('../../util')
+const { roundDecimal } = require('../../../src/util/math')
 
 test.before(async t => {
   await before({ name: 'event' })(t)
@@ -61,9 +62,7 @@ function checkStatsObject ({
     t.is(result.count, count)
 
     if (field) {
-      const divisor = Math.pow(10, avgPrecision)
-
-      t.is(result.avg, Math.round(avg * divisor) / divisor)
+      t.is(result.avg, roundDecimal(avg, avgPrecision))
       t.is(result.sum, sum)
       t.is(result.min, min)
       t.is(result.max, max)

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -267,6 +267,33 @@ test('get aggregated field stats with complex filters', async (t) => {
     field,
     events: events2
   })
+
+  const assetSupersetOf = {
+    customAttributes: {
+      seatingCapacity: 4
+    },
+    validated: true
+  }
+
+  const filters3 = `objectType=${objectType}&object=${encode(assetSupersetOf)}`
+
+  const { body: { results: events3 } } = await request(t.context.serverUrl)
+    .get(`/events?${filters3}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj3 } = await request(t.context.serverUrl)
+    .get(`/events/stats?groupBy=${groupBy}&field=${field}&${filters3}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkStatsObject({
+    t,
+    obj: obj3,
+    groupBy,
+    field,
+    events: events3
+  })
 })
 
 test('fails to get aggregated stats with non-number field', async (t) => {
@@ -541,6 +568,27 @@ test('list events with metadata object filters', async (t) => {
 
   t.is(obj7.results.length, obj7.nbResults)
   t.is(obj7.nbResults, 0)
+
+  const assetSupersetOf = {
+    customAttributes: {
+      seatingCapacity: 4
+    },
+    validated: true
+  }
+
+  const checkAssetEvent = event => {
+    t.is(event.object.customAttributes.seatingCapacity, 4)
+    t.is(event.object.validated, true)
+  }
+
+  const { body: obj8 } = await request(t.context.serverUrl)
+    .get(`/events?object=${encode(assetSupersetOf)}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  t.is(obj8.results.length, obj8.nbResults)
+  t.is(obj8.nbResults, 3)
+  obj8.results.forEach(checkAssetEvent)
 })
 
 test('finds an event', async (t) => {

--- a/test/unit/util/math.spec.js
+++ b/test/unit/util/math.spec.js
@@ -1,0 +1,13 @@
+require('dotenv').config()
+
+const test = require('ava')
+
+const {
+  roundDecimal
+} = require('../../../src/util/math')
+
+test('rounds number with precision', (t) => {
+  t.is(roundDecimal(8.325, 2), 8.33)
+  t.is(roundDecimal(8.325, 2, Math.floor), 8.32)
+  t.is(roundDecimal(8.325, 2, Math.ceil), 8.33)
+})

--- a/test/util.js
+++ b/test/util.js
@@ -1,5 +1,6 @@
 const { computeDate } = require('../src/util/time')
 const { getModels } = require('../src/models')
+const { roundDecimal } = require('../src/util/math')
 const _ = require('lodash')
 
 /**
@@ -15,7 +16,8 @@ module.exports = {
   computeDate,
   nullOrUndefinedFallback,
   getObjectEvent,
-  testEventMetadata
+  testEventMetadata,
+  checkStatsObject
 }
 
 /**
@@ -102,4 +104,106 @@ async function testEventMetadata ({
   else t.true(event.relatedObjectsIds === null, testMessage)
 
   if (metadata) t.deepEqual(event.metadata, metadata, testMessage)
+}
+
+/**
+ * @param {Object}   params
+ * @param {Object}   params.t - AVA test object
+ * @param {Object}   params.obj - stats object returned by API
+ * @param {String}   params.groupBy
+ * @param {String}   [params.field]
+ * @param {Object[]} params.results
+ * @param {Boolean}  [params.expandedGroupByField = true]
+ *   if false, result has no `groupBy` and `groupByValue`
+ *   if true, result has property [`groupBy`] with `groupByValue` as value
+ *   true: { groupBy: ..., groupByValue: ... }
+ *   false: { [groupBy]: groupByValue }
+ * @param {Number}   [avgPrecision = 2] - check the average precision
+ * @param {String}   [orderBy = 'count']
+ * @param {String}   [order = 'desc']
+ * @param {Function} [additionalResultCheckFn] - if defined, will perform additional check on `result`
+ */
+function checkStatsObject ({
+  t,
+  obj,
+  groupBy,
+  field,
+  results,
+  expandedGroupByField = true,
+  avgPrecision = 2,
+  orderBy = 'count',
+  order = 'desc',
+  additionalResultCheckFn
+}) {
+  // only consider results whose `groupBy` value is not `undefined`
+  results = results.filter(e => !_.isUndefined(_.get(e, groupBy)))
+  const resultsByType = _.groupBy(results, groupBy)
+
+  t.true(typeof obj === 'object')
+  t.true(typeof obj.nbResults === 'number')
+  t.true(typeof obj.nbPages === 'number')
+  t.true(typeof obj.page === 'number')
+  t.true(typeof obj.nbResultsPerPage === 'number')
+  t.true(Array.isArray(obj.results))
+  t.is(obj.nbResults, obj.results.length)
+
+  obj.results.forEach(result => {
+    const key = expandedGroupByField ? result.groupByValue : result[groupBy]
+    const results = resultsByType[key] || []
+    const count = results.length
+
+    const nullIfNone = (count, nb) => count === 0 ? null : nb
+
+    const avg = nullIfNone(count, results.reduce((nb, r) => nb + _.get(r, field), 0) / results.length)
+    const sum = nullIfNone(count, results.reduce((nb, r) => nb + _.get(r, field), 0))
+    const min = nullIfNone(count, results.reduce((nb, r) => Math.min(_.get(r, field), nb), _.get(results[0], field)))
+    const max = nullIfNone(count, results.reduce((nb, r) => Math.max(_.get(r, field), nb), _.get(results[0], field)))
+
+    if (expandedGroupByField) {
+      t.is(result.groupBy, groupBy)
+      t.is(typeof result.groupByValue, 'string')
+    } else {
+      t.is(typeof result[groupBy], 'string')
+    }
+
+    t.is(result.count, count)
+
+    if (field) {
+      t.is(result.avg, roundDecimal(avg, avgPrecision))
+
+      // Better compare the difference below a small threshold
+      // than performing a strict equality because of floating operation precision
+      // 8.1 + 8.2 = 16.299999999999997
+      const isEqual = (nb1, nb2) => Math.abs(nb1 - nb2) <= 1e-10 // not using Number.EPSILON because it's too small
+      t.true(isEqual(result.sum, sum))
+
+      t.is(result.min, min)
+      t.is(result.max, max)
+    } else {
+      t.is(result.avg, null)
+      t.is(result.sum, null)
+      t.is(result.min, null)
+      t.is(result.max, null)
+    }
+  })
+
+  const totalCount = obj.results.reduce((total, r) => total + r.count, 0)
+  t.is(totalCount, results.length)
+
+  // check order
+  let number
+  obj.results.forEach(result => {
+    if (typeof number === 'undefined') {
+      number = result[orderBy]
+    } else {
+      if (order === 'desc') t.true(number >= result[orderBy])
+      else t.true(number <= result[orderBy])
+
+      number = result[orderBy]
+    }
+
+    if (typeof additionalResultCheckFn === 'function') {
+      additionalResultCheckFn(result)
+    }
+  })
 }


### PR DESCRIPTION
Before only available in Documents and Ratings APIs,
aggregation is now added to Events API .

Same filters are applied to stats and list endpoints.
Moreover `groupBy` and `field` parameters can work with nested properties
such as event `metadata` or `object`,
which is important to aggregate all sort of data (core or custom events).

Improve documents error when `field` is specified while some values are non-number.

Add `object` filter in Event API