### PR TITLE
feat: load an intl polyfill to handle dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "handlebars": "^4.4.3",
     "http-errors": "^1.7.3",
     "intl": "^1.2.5",
+    "intl-format-cache": "^4.2.2",
     "intl-messageformat": "^4.4.0",
     "jose": "^1.10.1",
     "jsonwebtoken": "^8.5.1",

--- a/plugins/email/routes/email.js
+++ b/plugins/email/routes/email.js
@@ -58,6 +58,7 @@ function init (server, { middlewares, helpers } = {}) {
       'data',
       'locale',
       'currency',
+      'timezone',
       'from',
       'fromName',
       'to',

--- a/plugins/email/services/email.js
+++ b/plugins/email/services/email.js
@@ -19,7 +19,8 @@ module.exports = function createService (deps) {
   const {
     createError,
     utils: {
-      locale: { parseLocale }
+      locale: { parseLocale },
+      time: { isValidTimezone }
     },
 
     configRequester,
@@ -96,6 +97,7 @@ module.exports = function createService (deps) {
       name,
       locale: requestedLocale,
       currency: requestedCurrency,
+      timezone,
       data,
       from,
 
@@ -107,6 +109,8 @@ module.exports = function createService (deps) {
       to,
       replyTo
     } = req
+
+    if (timezone && !isValidTimezone(timezone)) throw createError(422, 'Invalid timezone')
 
     const emailParams = await checkAndGetEmailParameters({
       platformId,
@@ -180,7 +184,8 @@ module.exports = function createService (deps) {
     try {
       const generatedResult = generateGeneralTemplate(templateFields, enrichedData, {
         locale,
-        currency
+        currency,
+        timezone
       })
 
       newTemplate = generatedResult.newTemplate

--- a/plugins/email/test/email.spec.js
+++ b/plugins/email/test/email.spec.js
@@ -549,6 +549,8 @@ test('sends an email via a template with ICU content', async (t) => {
     })
     .expect(200)
 
+  const availableDateStr = '2019-03-15T12:45:12.000Z'
+
   const payload = {
     name: 'registration',
     to: 'Example user <test@example.com>',
@@ -559,7 +561,7 @@ test('sends an email via a template with ICU content', async (t) => {
       nbAssets: 7,
       discountRate: 0.2,
       deliveryMethod: 'home',
-      availableDate: '2019-03-15T12:45:12.000Z'
+      availableDate: availableDateStr
     },
     locale: 'fr'
   }
@@ -578,7 +580,12 @@ test('sends an email via a template with ICU content', async (t) => {
   t.true(html.includes('une réduction de 20 %'))
   t.true(html.includes('Votre colis sera livré à votre domicile'))
   t.true(html.includes('à partir du 15/03/2019 (vendredi 15 mars 2019)'))
-  t.true(html.includes('13:45:12'))
+
+  // get hours, minutes and seconds from Date object
+  // because they may differ depending on local time
+  const availableDate = new Date(availableDateStr)
+  const time = `${availableDate.getHours()}:${availableDate.getMinutes()}:${availableDate.getSeconds()}`
+  t.true(html.includes(time))
 })
 
 test('uses general email content when specific email content is missing', async (t) => {

--- a/plugins/email/util/template.js
+++ b/plugins/email/util/template.js
@@ -107,16 +107,18 @@ function computeGeneralFieldsBlock (fields) {
  * @param {Object}   [options]
  * @param {String}   [options.locale]
  * @param {String}   [options.currency]
+ * @param {String}   [options.timezone]
  * @param {Function} [options.beforeCompileTemplate] - can alter fields before Handlebars compilation
  */
 function generateTemplate ({ template, fields, data, options = {} }) {
   const {
     locale,
     currency,
+    timezone,
     beforeCompileTemplate
   } = options
 
-  let newFields = formatMessages(fields, data, { locale, currency })
+  let newFields = formatMessages(fields, data, { locale, currency, timezone })
 
   if (typeof beforeCompileTemplate === 'function') {
     newFields = beforeCompileTemplate(newFields)

--- a/plugins/email/versions/validation/email.js
+++ b/plugins/email/versions/validation/email.js
@@ -71,6 +71,7 @@ schemas['2019-05-20'].sendTemplate = {
     data: singleLvlObjectSchema,
     locale: Joi.string(),
     currency: Joi.string(),
+    timezone: Joi.string(),
     from: emailSchema,
     to: Joi.alternatives().try(
       emailSchema,

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const corsMiddleware = require('restify-cors-middleware2')
 const socketIO = require('socket.io')
 const apm = require('elastic-apm-node')
 const { isActive: isApmActive, addRequestContext } = require('./apm')
+const { applyIntlPolyfill } = require('./src/util/intl')
 
 const cors = corsMiddleware({
   origin: ['*'], // default, only appropriate domain is included in response
@@ -214,6 +215,8 @@ function loadServer () {
 
   server.pre(cors.preflight)
   server.use(cors.actual)
+
+  applyIntlPolyfill()
 
   const allowedErrorFields = [
     'message',

--- a/src/services/workflow.js
+++ b/src/services/workflow.js
@@ -389,6 +389,9 @@ function start ({ communication, serverPort }) {
         // Users must be informed before any major or minor version updates
         // but (security) patch updates should be applied on an ongoing basis.
         vm.freeze(_, '_')
+
+        // Expose Intl with all loaded locales
+        vm.freeze(global.Intl, 'Intl')
       }
 
       let currentWorkflowId

--- a/src/util/intl.js
+++ b/src/util/intl.js
@@ -1,0 +1,40 @@
+// With current version (12.7) of Node.js, `small-icu` is embedded by default
+// (only English support for dates and numbers)
+// https://nodejs.org/api/intl.html#intl_options_for_building_node_js
+
+// There is a plan to include `full-icu` by default in a future version
+// https://github.com/nodejs/node/pull/29522
+
+// For the time being, we need to apply a polyfill to support all locales.
+// Here's a function to detect if some locale is missing:
+// https://nodejs.org/api/intl.html#intl_detecting_internationalization_support
+function hasFullICU () {
+  try {
+    const january = new Date(9e8)
+    const spanish = new Intl.DateTimeFormat('es', { month: 'long' })
+    return spanish.format(january) === 'enero'
+  } catch (err) {
+    return false
+  }
+}
+
+function applyIntlPolyfill () {
+  if (hasFullICU()) return
+
+  const IntlPolyfill = require('intl')
+
+  if (global.Intl) {
+    // Intl exists, but it doesn't have the data we need, so load the
+    // polyfill and patch the constructors we need with the polyfill's.
+    Intl.NumberFormat = IntlPolyfill.NumberFormat
+    Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat
+  } else {
+    // No Intl, so use and load the polyfill.
+    global.Intl = IntlPolyfill
+  }
+}
+
+module.exports = {
+  hasFullICU,
+  applyIntlPolyfill
+}

--- a/test/integration/api/workflow.spec.js
+++ b/test/integration/api/workflow.spec.js
@@ -194,7 +194,7 @@ test('creates several single-step Stelace workflows', async (t) => {
 
           // localized date in Chinese format
           localizedDate: `
-            new Intl.DateTimeFormat('zh-CH', {
+            new Intl.DateTimeFormat('zh-CN', {
               day: 'numeric',
               month : 'long',
               year : 'numeric'

--- a/test/integration/api/workflow.spec.js
+++ b/test/integration/api/workflow.spec.js
@@ -191,6 +191,15 @@ test('creates several single-step Stelace workflows', async (t) => {
           startDate: 'new Date().toISOString()',
           endDate: 'new Date(new Date().getTime() + (14 * 24 * 60 * 60 * 1000)).toISOString()',
           isCurrentTest: '_.get(changesRequested, "metadata.singleStepWorkflow")',
+
+          // localized date in Chinese format
+          localizedDate: `
+            new Intl.DateTimeFormat('zh-CH', {
+              day: 'numeric',
+              month : 'long',
+              year : 'numeric'
+            }).format(new Date('2019-02-05'))
+          `,
           nestedObjects: [
             {
               nested: true
@@ -210,7 +219,8 @@ test('creates several single-step Stelace workflows', async (t) => {
             futurePrice: 'computed.futurePrice',
             var: 'env.TEST_ENV_VARIABLE',
             otherVar: 'env.OTHER_ENV_VARIABLE', // should be undefined (cf. config fixtures)
-            nestedObjects: 'computed.nestedObjects'
+            nestedObjects: 'computed.nestedObjects',
+            localizedDate: 'computed.localizedDate'
           },
           platformData: {
             platformDataField: '"test"'
@@ -279,6 +289,7 @@ test('creates several single-step Stelace workflows', async (t) => {
   t.is(workflow1LogsCall1.metadata.endpointPayload.metadata.futurePrice, 24)
   t.is(workflow1LogsCall1.metadata.endpointPayload.metadata.var, 'true')
   t.deepEqual(workflow1LogsCall1.metadata.endpointPayload.metadata.nestedObjects, [{ nested: true }])
+  t.is(workflow1LogsCall1.metadata.endpointPayload.metadata.localizedDate, '2019年2月5日')
   t.is(typeof workflow1LogsCall1.metadata.endpointPayload.metadata.otherVar, 'undefined')
   t.is(workflow1AfterRun1.stats.nbActionsCompleted, 1)
   t.is(workflow1AfterRun1.stats.nbTimesRun, workflow1AfterRun1.stats.nbWorkflowNotifications)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,6 +4281,11 @@ interpret@^1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
+intl-format-cache@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.2.tgz#4e745d4cda3aa9df2495f0493bed4c6c4ff7093d"
+  integrity sha512-7tY3XadLn8rMHiYVUzH/6NmOe944nJ59LdAWuFm64/m2OfFAEkZTtTHxrEtoxq7HWFddX4aRwDb9P8KB5Z2AvQ==
+
 intl-messageformat-parser@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz#0eb14c5618333be4c95c409457b66c8c33ddcc01"


### PR DESCRIPTION
With current version of Node.js (12.7), there is only a partial
support of Intl.
https://nodejs.org/api/intl.html#intl_options_for_building_node_js

For instance, full-text dates are localized only in English.
We need to load a polyfill to handle it,
until Node.js embed `full-icu` by default.