### PR TITLE
feat: verify and decrypt an authentication information

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -425,7 +425,6 @@ function loadServer () {
     const isHomeUrl = req.url === '/'
     const isTokenConfirmCheckUrl = req.url.startsWith('/token/check/') && req.url !== '/token/check/request'
     const isSSOUrl = req.url.startsWith('/auth/sso')
-    const isAuthCheckUrl = req.url === '/auth/check'
 
     const { spec: { optionalApiKey, manualAuth } } = req.getRoute() || { spec: {} }
     req._optionalApiKeyRoute = Boolean(optionalApiKey) // Authorization header may still be required (e.g. token)
@@ -438,8 +437,7 @@ function loadServer () {
       req._optionalApiKeyRoute ||
       req._manualAuthRoute ||
       isTokenConfirmCheckUrl ||
-      isSSOUrl ||
-      isAuthCheckUrl
+      isSSOUrl
 
     req.apmSpans.requestInit && req.apmSpans.requestInit.end()
     req.apmSpans.requestInit = null
@@ -513,9 +511,7 @@ function loadServer () {
     const apmSpan = apm.startSpan('Parse Authorization and get platform info')
 
     try {
-      const isAuthCheckUrl = req.url === '/auth/check'
-
-      parseAuthorizationHeader(req, { noThrowIfError: isAuthCheckUrl })
+      parseAuthorizationHeader(req)
     } catch (err) { // still trying to parse authorization header for convenience when not required
       if (!req._manualAuthRoute) {
         apmSpan && apmSpan.end()

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -271,6 +271,28 @@ function init (server, { middlewares, helpers } = {}) {
 
     return requester.send(params)
   }))
+
+  server.post({
+    name: 'auth.check',
+    path: '/auth/check'
+  }, wrapAction(async (req, res) => {
+    const {
+      apiKey,
+      authorization
+    } = req.body || {} // body can be missing if only the header `authorization` is passed
+    const parsedAuthorizationHeader = req.authorization
+    const authorizationHeader = req.headers.authorization
+
+    const params = populateRequesterParams(req)({
+      type: 'authCheck',
+      apiKey,
+      authorization,
+      parsedAuthorizationHeader,
+      authorizationHeader
+    })
+
+    return requester.send(params)
+  }))
 }
 
 function start ({ communication }) {

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -279,16 +279,12 @@ function init (server, { middlewares, helpers } = {}) {
     const {
       apiKey,
       authorization
-    } = req.body || {} // body can be missing if only the header `authorization` is passed
-    const parsedAuthorizationHeader = req.authorization
-    const authorizationHeader = req.headers.authorization
+    } = req.body
 
     const params = populateRequesterParams(req)({
       type: 'authCheck',
       apiKey,
-      authorization,
-      parsedAuthorizationHeader,
-      authorizationHeader
+      authorization
     })
 
     return requester.send(params)

--- a/src/services/signal.js
+++ b/src/services/signal.js
@@ -167,21 +167,23 @@ function start ({ communication, stelaceIO }) {
           else if (typeof authToken !== 'string') return disconnect('String authentication token expected')
 
           try {
-            const { decodedToken } = await checkAuthToken({
+            const { decodedToken, isTokenExpired } = await checkAuthToken({
               authToken,
               platformId,
               env,
               apmLabel: 'Signal authToken check'
             })
 
-            userId = decodedToken.sub || decodedToken.userId
-            hasInternalUserId = isValidObjectId({
-              id: userId,
-              prefix: User.idPrefix,
-              platformId,
-              env
-            })
-            if (hasInternalUserId) channelsToJoin.push(prefixChannel(userId, { platformId, env }))
+            if (!isTokenExpired) {
+              userId = decodedToken.sub || decodedToken.userId
+              hasInternalUserId = isValidObjectId({
+                id: userId,
+                prefix: User.idPrefix,
+                platformId,
+                env
+              })
+              if (hasInternalUserId) channelsToJoin.push(prefixChannel(userId, { platformId, env }))
+            }
           } catch (err) {
             return disconnect('Invalid authentication token')
           }

--- a/src/versions/validation/authentication.js
+++ b/src/versions/validation/authentication.js
@@ -90,6 +90,8 @@ schemas['2019-05-20'].authCheck = {
     apiKey: Joi.string(),
     authorization: Joi.string()
   })
+    .xor('apiKey', 'authorization')
+    .required()
 }
 
 const validationVersions = {
@@ -121,6 +123,10 @@ const validationVersions = {
     {
       target: 'auth.ssoLogoutCallback',
       schema: schemas['2019-05-20'].ssoLogoutCallback
+    },
+    {
+      target: 'auth.check',
+      schema: schemas['2019-05-20'].authCheck
     },
     {
       target: 'password.changePassword',

--- a/src/versions/validation/authentication.js
+++ b/src/versions/validation/authentication.js
@@ -85,6 +85,12 @@ schemas['2019-05-20'].confirmTokenCheck = {
     redirect: Joi.boolean()
   })
 }
+schemas['2019-05-20'].authCheck = {
+  body: Joi.object().keys({
+    apiKey: Joi.string(),
+    authorization: Joi.string()
+  })
+}
 
 const validationVersions = {
   '2019-05-20': [

--- a/test/integration/api/authentication.spec.js
+++ b/test/integration/api/authentication.spec.js
@@ -2009,6 +2009,9 @@ test('check authentication information', async (t) => {
   const { body: apiKeyCheck1 } = await request(t.context.serverUrl)
     .post('/auth/check')
     .send({ apiKey })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(200)
 
   t.is(apiKeyCheck1.valid, true)
@@ -2019,6 +2022,9 @@ test('check authentication information', async (t) => {
   const { body: apiKeyCheck2 } = await request(t.context.serverUrl)
     .post('/auth/check')
     .send({ apiKey: 'invalid_api_key' })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(200)
 
   t.is(apiKeyCheck2.valid, false)
@@ -2035,6 +2041,9 @@ test('check authentication information', async (t) => {
     .send({
       authorization: apiKeyAuthorization
     })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(200)
 
   t.is(authorizationCheck1.valid, true)
@@ -2046,6 +2055,9 @@ test('check authentication information', async (t) => {
     .post('/auth/check')
     .send({
       authorization: invalidApiKeyAuthorization
+    })
+    .set({
+      authorization: apiKeyAuthorization
     })
     .expect(200)
 
@@ -2059,6 +2071,9 @@ test('check authentication information', async (t) => {
     .send({
       authorization: userAuthorization
     })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(200)
 
   t.is(authorizationCheck3.valid, true)
@@ -2070,6 +2085,9 @@ test('check authentication information', async (t) => {
     .post('/auth/check')
     .send({
       authorization: invalidUserAuthorization1
+    })
+    .set({
+      authorization: apiKeyAuthorization
     })
     .expect(200)
 
@@ -2083,6 +2101,9 @@ test('check authentication information', async (t) => {
     .send({
       authorization: invalidUserAuthorization1
     })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(200)
 
   t.is(authorizationCheck5.valid, false)
@@ -2094,6 +2115,9 @@ test('check authentication information', async (t) => {
     .post('/auth/check')
     .send({
       authorization: invalidUserAuthorization2
+    })
+    .set({
+      authorization: apiKeyAuthorization
     })
     .expect(200)
 
@@ -2111,6 +2135,9 @@ test('check authentication information', async (t) => {
     .set({
       authorization: apiKeyAuthorization // authorization isn't used in this endpoint
     })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(400)
 
   // /////////////////// //
@@ -2123,6 +2150,9 @@ test('check authentication information', async (t) => {
       apiKey,
       authorization: userAuthorization
     })
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(400)
 
   // ////////////////// //
@@ -2131,5 +2161,16 @@ test('check authentication information', async (t) => {
 
   await request(t.context.serverUrl)
     .post('/auth/check')
+    .set({
+      authorization: apiKeyAuthorization
+    })
     .expect(400)
+
+  // /////////////// //
+  // MISSING API KEY //
+  // /////////////// //
+
+  await request(t.context.serverUrl)
+    .post('/auth/check')
+    .expect(401)
 })


### PR DESCRIPTION
Up to now, external systems cannot determine if a Stelace API key
or a user token is valid or not.

If some custom logic is implemented in external systems
(e.g. serverless architecture),
this can be helpful to restrict users who are able to
trigger this logic by inspecting the authentication
information
(e.g. some transaction logic can only be triggered by users
that are part of the transaction).