### PR TITLE
perf!: paginated endpoints with cursor pagination

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const utils = {
   list: require('./src/util/list'),
   listQueryBuilder: require('./src/util/listQueryBuilder'),
   locale: require('./src/util/locale'),
+  pagination: require('./src/util/pagination'),
   pricing: require('./src/util/pricing'),
   time: require('./src/util/time'),
   transaction: require('./src/util/transaction'),

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "aws-param-store": "^3.2.0",
     "aws-sdk": "^2.720.0",
     "bcrypt": "^5.0.0",
+    "big.js": "^5.2.2",
     "bluebird": "^3.7.2",
     "cheerio": "^1.0.0-rc.3",
     "cote": "1.0.0",

--- a/plugins/rating/routes/rating.js
+++ b/plugins/rating/routes/rating.js
@@ -18,8 +18,14 @@ function init (server, { middlewares, helpers } = {}) {
   const statsFields = [
     'orderBy',
     'order',
-    'page',
     'nbResultsPerPage',
+
+    // offset pagination
+    'page',
+
+    // cursor pagination
+    'startingAfter',
+    'endingBefore',
 
     'groupBy',
     'computeRanking',
@@ -76,8 +82,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'authorId',

--- a/plugins/rating/services/rating.js
+++ b/plugins/rating/services/rating.js
@@ -27,8 +27,14 @@ module.exports = function createService (deps) {
     const {
       orderBy,
       order,
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       groupBy,
       computeRanking,
@@ -54,13 +60,22 @@ module.exports = function createService (deps) {
       groupBy: documentGroupBy,
       orderBy,
       order,
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
+
       label,
       authorId,
       targetId,
       avgPrecision: 0,
-      computeRanking
+      computeRanking,
+
+      _useOffsetPagination: req._useOffsetPagination,
     }
 
     const data = {}
@@ -118,8 +133,14 @@ module.exports = function createService (deps) {
       id,
       orderBy,
       order,
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       authorId,
       targetId,
@@ -135,11 +156,20 @@ module.exports = function createService (deps) {
       id,
       orderBy,
       order,
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
+
+      page,
       authorId,
       targetId,
-      label
+      label,
+
+      _useOffsetPagination: req._useOffsetPagination,
     }
 
     const data = {}

--- a/plugins/rating/test/rating.spec.js
+++ b/plugins/rating/test/rating.spec.js
@@ -13,6 +13,10 @@ const {
   checkOffsetPaginationScenario,
   checkOffsetPaginatedListObject,
   checkOffsetPaginatedStatsObject,
+
+  checkCursorPaginationScenario,
+  checkCursorPaginatedListObject,
+  checkCursorPaginatedStatsObject,
 } = util
 
 test.before(async t => {
@@ -26,7 +30,7 @@ test.after(after())
 test.serial('gets simple rating stats with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['rating:stats:all'] })
 
-  await checkOffsetPaginationScenario({
+  await checkCursorPaginationScenario({
     t,
     endpointUrl: '/ratings/stats?groupBy=authorId',
     authorizationHeaders,
@@ -57,7 +61,7 @@ test.serial('gets simple rating stats', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -111,7 +115,7 @@ test.serial('gets aggregated rating stats with ranking', async (t) => {
 
   let ranking
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -125,7 +129,7 @@ test.serial('gets aggregated rating stats with ranking', async (t) => {
       t.is(typeof result.ranking, 'number')
       t.is(typeof result.lowestRanking, 'number')
 
-      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+      t.is(result.lowestRanking, obj.results.length) // is true because there is no filter
 
       // check ranking order
       if (typeof ranking === 'undefined') {
@@ -198,7 +202,7 @@ test('gets aggregated rating stats with multiple labels', async (t) => {
 test.serial('lists ratings with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['rating:list:all'] })
 
-  await checkOffsetPaginationScenario({
+  await checkCursorPaginationScenario({
     t,
     endpointUrl: '/ratings',
     authorizationHeaders,
@@ -213,7 +217,7 @@ test('lists ratings with id filter', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedListObject(t, obj)
+  checkCursorPaginatedListObject(t, obj)
   t.is(obj.results.length, 1)
 })
 
@@ -227,7 +231,6 @@ test('lists ratings with advanced filter', async (t) => {
 
   const obj1 = result1.body
 
-  t.is(obj1.results.length, obj1.nbResults)
   obj1.results.forEach(rating => {
     t.true(['usr_WHlfQps1I3a1gJYz2I3a', 'user-external-id'].includes(rating.authorId))
   })
@@ -239,7 +242,6 @@ test('lists ratings with advanced filter', async (t) => {
 
   const obj2 = result2.body
 
-  t.is(obj2.results.length, obj2.nbResults)
   obj2.results.forEach(rating => {
     t.true(['usr_WHlfQps1I3a1gJYz2I3a', 'user-external-id'].includes(rating.authorId))
   })
@@ -251,7 +253,6 @@ test('lists ratings with advanced filter', async (t) => {
 
   const obj3 = result3.body
 
-  t.is(obj3.results.length, obj3.nbResults)
   obj3.results.forEach(rating => {
     t.true(['usr_T2VfQps1I3a1gJYz2I3a'].includes(rating.targetId))
   })
@@ -263,7 +264,6 @@ test('lists ratings with advanced filter', async (t) => {
 
   const obj4 = result4.body
 
-  t.is(obj4.results.length, obj4.nbResults)
   obj4.results.forEach(rating => {
     t.true(['ast_0TYM7rs1OwP1gQRuCOwP'].includes(rating.assetId))
     t.true(['trn_UG1fQps1I3a1gJYz2I3a'].includes(rating.transactionId))
@@ -282,7 +282,7 @@ test('lists ratings with label filter', async (t) => {
     t.true(['main:friendliness', 'main:pricing'].includes(rating.label))
   }
 
-  checkOffsetPaginatedListObject(t, obj, { checkResultsFn })
+  checkCursorPaginatedListObject(t, obj, { checkResultsFn })
 })
 
 test('lists ratings with wildcard label filter', async (t) => {
@@ -294,7 +294,7 @@ test('lists ratings with wildcard label filter', async (t) => {
     .expect(200)
 
   const checkResultsFn = (t, rating) => t.true(rating.label.startsWith('main:'))
-  checkOffsetPaginatedListObject(t, obj, { checkResultsFn })
+  checkCursorPaginatedListObject(t, obj, { checkResultsFn })
 })
 
 test('finds a rating', async (t) => {
@@ -593,4 +593,182 @@ test('fails to update a rating if missing or invalid parameters', async (t) => {
   t.true(error.message.includes('"comment" must be a string'))
   t.true(error.message.includes('"metadata" must be of type object'))
   t.true(error.message.includes('"platformData" must be of type object'))
+})
+
+// //////// //
+// VERSIONS //
+// //////// //
+
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('2019-05-20: gets simple rating stats with pagination', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['rating:stats:all']
+  })
+
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/ratings/stats?groupBy=authorId',
+    authorizationHeaders,
+    orderBy: 'avg'
+  })
+})
+
+// run this test serially because there is no filter and some other tests create events
+// that can turn the check on `count` property incorrect
+test.serial('2019-05-20: gets simple rating stats', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'rating:stats:all',
+      'rating:list:all'
+    ]
+  })
+
+  const groupBy = 'authorId'
+
+  const { body: { results: ratings } } = await request(t.context.serverUrl)
+    .get('/ratings')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/ratings/stats?groupBy=${groupBy}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field: 'score', // implicit for Rating API
+    avgPrecision: 0, // implicit for Rating API
+    results: ratings,
+    orderBy: 'avg',
+    order: 'desc',
+    expandedGroupByField: false
+  })
+
+  // cf. plugin middleware test below
+  t.is(typeof obj.workingTestMiddleware, 'undefined')
+})
+
+// run this test serially because there is no filter and some other tests create events
+// that can turn the check on `count` property incorrect
+test.serial('2019-05-20: gets aggregated rating stats with ranking', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'rating:stats:all',
+      'rating:list:all'
+    ]
+  })
+
+  const groupBy = 'authorId'
+
+  const { body: { results: ratings } } = await request(t.context.serverUrl)
+    .get('/ratings')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/ratings/stats?groupBy=${groupBy}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  let ranking
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field: 'score', // implicit for Rating API
+    avgPrecision: 0, // implicit for Rating API
+    results: ratings,
+    orderBy: 'avg',
+    order: 'desc',
+    expandedGroupByField: false,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
+
+      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+
+      // check ranking order
+      if (typeof ranking === 'undefined') {
+        ranking = result.ranking
+      } else {
+        t.true(ranking < result.ranking)
+      }
+    }
+  })
+})
+
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('2019-05-20: lists ratings with pagination', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['rating:list:all']
+  })
+
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/ratings',
+    authorizationHeaders,
+  })
+})
+
+test('2019-05-20: lists ratings with id filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['rating:list:all']
+  })
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get('/ratings?id=rtg_2l7fQps1I3a1gJYz2I3a')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedListObject(t, obj)
+  t.is(obj.results.length, 1)
+})
+
+test('2019-05-20: lists ratings with label filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['rating:list:all']
+  })
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get('/ratings?label=main:friendliness,main:pricing')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const checkResultsFn = (t, rating) => {
+    t.true(['main:friendliness', 'main:pricing'].includes(rating.label))
+  }
+
+  checkOffsetPaginatedListObject(t, obj, { checkResultsFn })
+})
+
+test('2019-05-20: lists ratings with wildcard label filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['rating:list:all']
+  })
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get('/ratings?label=main:*')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const checkResultsFn = (t, rating) => t.true(rating.label.startsWith('main:'))
+  checkOffsetPaginatedListObject(t, obj, { checkResultsFn })
 })

--- a/plugins/rating/versions/validation/rating.js
+++ b/plugins/rating/versions/validation/rating.js
@@ -16,7 +16,7 @@ module.exports = function createValidation (deps) {
   const {
     utils: {
       validation: { objectIdParamsSchema },
-      list: { DEFAULT_NB_RESULTS_PER_PAGE }
+      pagination: { DEFAULT_NB_RESULTS_PER_PAGE }
     }
   } = deps
 

--- a/plugins/rating/versions/validation/rating.js
+++ b/plugins/rating/versions/validation/rating.js
@@ -23,6 +23,31 @@ module.exports = function createValidation (deps) {
   const schemas = {}
 
   // ////////// //
+  // 2020-08-10 //
+  // ////////// //
+  schemas['2020-08-10'] = {}
+  schemas['2020-08-10'].getStats = () => ({
+    query: schemas['2019-05-20'].getStats.query
+      .fork('page', schema => schema.forbidden())
+      .keys({
+        // cursor pagination
+        startingAfter: Joi.string(),
+        endingBefore: Joi.string(),
+      })
+      .oxor('startingAfter', 'endingBefore')
+  })
+  schemas['2020-08-10'].list = () => ({
+    query: schemas['2019-05-20'].list.query
+      .fork('page', schema => schema.forbidden())
+      .keys({
+        // cursor pagination
+        startingAfter: Joi.string(),
+        endingBefore: Joi.string(),
+      })
+      .oxor('startingAfter', 'endingBefore')
+  })
+
+  // ////////// //
   // 2019-05-20 //
   // ////////// //
   schemas['2019-05-20'] = {}
@@ -94,6 +119,17 @@ module.exports = function createValidation (deps) {
   }
 
   const validationVersions = {
+    '2020-08-10': [
+      {
+        target: 'rating.getStats',
+        schema: schemas['2020-08-10'].getStats
+      },
+      {
+        target: 'rating.list',
+        schema: schemas['2020-08-10'].list
+      },
+    ],
+
     '2019-05-20': [
       {
         target: 'rating.getStats',

--- a/plugins/rating/versions/validation/rating.js
+++ b/plugins/rating/versions/validation/rating.js
@@ -15,7 +15,7 @@ const orderByFields = [
 module.exports = function createValidation (deps) {
   const {
     utils: {
-      validation: { objectIdParamsSchema },
+      validation: { objectIdParamsSchema, replaceOffsetWithCursorPagination },
       pagination: { DEFAULT_NB_RESULTS_PER_PAGE }
     }
   } = deps
@@ -27,24 +27,10 @@ module.exports = function createValidation (deps) {
   // ////////// //
   schemas['2020-08-10'] = {}
   schemas['2020-08-10'].getStats = () => ({
-    query: schemas['2019-05-20'].getStats.query
-      .fork('page', schema => schema.forbidden())
-      .keys({
-        // cursor pagination
-        startingAfter: Joi.string(),
-        endingBefore: Joi.string(),
-      })
-      .oxor('startingAfter', 'endingBefore')
+    query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].getStats.query)
   })
   schemas['2020-08-10'].list = () => ({
-    query: schemas['2019-05-20'].list.query
-      .fork('page', schema => schema.forbidden())
-      .keys({
-        // cursor pagination
-        startingAfter: Joi.string(),
-        endingBefore: Joi.string(),
-      })
-      .oxor('startingAfter', 'endingBefore')
+    query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
   })
 
   // ////////// //

--- a/plugins/saved-search/routes/savedSearch.js
+++ b/plugins/saved-search/routes/savedSearch.js
@@ -25,8 +25,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'userId'

--- a/plugins/saved-search/services/savedSearch.js
+++ b/plugins/saved-search/services/savedSearch.js
@@ -27,8 +27,14 @@ module.exports = function createService (deps) {
       id,
       orderBy,
       order,
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       userId
     } = req
@@ -39,9 +45,18 @@ module.exports = function createService (deps) {
       id,
       orderBy,
       order,
-      page,
       nbResultsPerPage,
-      authorId: userId
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
+
+      authorId: userId,
+
+      _useOffsetPagination: req._useOffsetPagination,
     }
 
     const paginationResult = await documentRequester.communicate(req)(documentParams)

--- a/plugins/saved-search/test/savedSearch.spec.js
+++ b/plugins/saved-search/test/savedSearch.spec.js
@@ -7,7 +7,8 @@ const {
   testTools: {
     lifecycle,
     auth,
-    fixtures: { search: searchFixtures }
+    fixtures: { search: searchFixtures },
+    util: { checkOffsetPaginationScenario }
   },
   utils: {
     time: { computeDate }
@@ -72,20 +73,15 @@ test.before(async t => {
 // test.beforeEach(beforeEach()) // Concurrent tests are much faster
 test.after(after())
 
-test('lists saved searches', async (t) => {
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('lists saved searches with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['savedSearch:list:all'] })
 
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/search')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/search',
+    authorizationHeaders,
+  })
 })
 
 test('lists saved searches with id filter', async (t) => {

--- a/plugins/saved-search/test/savedSearch.spec.js
+++ b/plugins/saved-search/test/savedSearch.spec.js
@@ -8,7 +8,10 @@ const {
     lifecycle,
     auth,
     fixtures: { search: searchFixtures },
-    util: { checkOffsetPaginationScenario }
+    util: {
+      checkOffsetPaginationScenario,
+      checkOffsetPaginatedListObject,
+    }
   },
   utils: {
     time: { computeDate }
@@ -87,23 +90,17 @@ test.serial('lists saved searches with pagination', async (t) => {
 test('lists saved searches with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['savedSearch:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/search?id=sch_2l7fQps1I3a1gJYz2I3a,sch_emdfQps1I3a1gJYz2I3a')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
-  t.is(obj.nbResults, 2)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 2)
-
-  obj.results.forEach(savedSearch => {
+  const checkResultsFn = (t, savedSearch) => {
     t.true(['sch_2l7fQps1I3a1gJYz2I3a', 'sch_emdfQps1I3a1gJYz2I3a'].includes(savedSearch.id))
-  })
+  }
+
+  checkOffsetPaginatedListObject(t, obj, { checkResultsFn })
+  t.is(obj.results.length, 2)
 })
 
 test('lists saved searches with advanced filter', async (t) => {

--- a/plugins/saved-search/versions/validation/savedSearch.js
+++ b/plugins/saved-search/versions/validation/savedSearch.js
@@ -17,6 +17,21 @@ module.exports = function createValidation (deps) {
   const schemas = {}
 
   // ////////// //
+  // 2020-08-10 //
+  // ////////// //
+  schemas['2020-08-10'] = {}
+  schemas['2020-08-10'].list = () => ({
+    query: schemas['2019-05-20'].list.query
+      .fork('page', schema => schema.forbidden())
+      .keys({
+        // cursor pagination
+        startingAfter: Joi.string(),
+        endingBefore: Joi.string(),
+      })
+      .oxor('startingAfter', 'endingBefore')
+  })
+
+  // ////////// //
   // 2019-05-20 //
   // ////////// //
   schemas['2019-05-20'] = {}
@@ -54,6 +69,13 @@ module.exports = function createValidation (deps) {
   }
 
   const validationVersions = {
+    '2020-08-10': [
+      {
+        target: 'savedSearch.list',
+        schema: schemas['2020-08-10'].list
+      },
+    ],
+
     '2019-05-20': [
       {
         target: 'savedSearch.list',

--- a/plugins/saved-search/versions/validation/savedSearch.js
+++ b/plugins/saved-search/versions/validation/savedSearch.js
@@ -10,7 +10,7 @@ module.exports = function createValidation (deps) {
   const {
     utils: {
       validation: { objectIdParamsSchema },
-      list: { DEFAULT_NB_RESULTS_PER_PAGE }
+      pagination: { DEFAULT_NB_RESULTS_PER_PAGE }
     }
   } = deps
 

--- a/plugins/saved-search/versions/validation/savedSearch.js
+++ b/plugins/saved-search/versions/validation/savedSearch.js
@@ -9,7 +9,7 @@ const orderByFields = [
 module.exports = function createValidation (deps) {
   const {
     utils: {
-      validation: { objectIdParamsSchema },
+      validation: { objectIdParamsSchema, replaceOffsetWithCursorPagination },
       pagination: { DEFAULT_NB_RESULTS_PER_PAGE }
     }
   } = deps
@@ -21,14 +21,7 @@ module.exports = function createValidation (deps) {
   // ////////// //
   schemas['2020-08-10'] = {}
   schemas['2020-08-10'].list = () => ({
-    query: schemas['2019-05-20'].list.query
-      .fork('page', schema => schema.forbidden())
-      .keys({
-        // cursor pagination
-        startingAfter: Joi.string(),
-        endingBefore: Joi.string(),
-      })
-      .oxor('startingAfter', 'endingBefore')
+    query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
   })
 
   // ////////// //

--- a/server/index.js
+++ b/server/index.js
@@ -700,6 +700,7 @@ function getAuthorizationParams (req) {
     _plan: req._plan, // can be set by some plugin
     _selectedVersion: req._selectedVersion,
     _workflow: req._workflow,
+    _useOffsetPagination: req._useOffsetPagination,
   }
 }
 

--- a/src/routes/apiKey.js
+++ b/src/routes/apiKey.js
@@ -25,8 +25,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'createdDate',

--- a/src/routes/assessment.js
+++ b/src/routes/assessment.js
@@ -20,8 +20,14 @@ function init (server, { middlewares, helpers } = {}) {
   ]), wrapAction(async (req, res) => {
     const fields = [
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'assetId'
     ]

--- a/src/routes/asset.js
+++ b/src/routes/asset.js
@@ -21,8 +21,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'createdDate',

--- a/src/routes/availability.js
+++ b/src/routes/availability.js
@@ -44,8 +44,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'assetId'
     ]

--- a/src/routes/customAttribute.js
+++ b/src/routes/customAttribute.js
@@ -20,8 +20,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id'
     ]

--- a/src/routes/document.js
+++ b/src/routes/document.js
@@ -20,8 +20,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'field',
       'groupBy',
@@ -57,8 +63,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'label',

--- a/src/routes/entry.js
+++ b/src/routes/entry.js
@@ -21,8 +21,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'collection',

--- a/src/routes/event.js
+++ b/src/routes/event.js
@@ -20,8 +20,9 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+      'startingAfter',
+      'endingBefore',
 
       'groupBy',
 
@@ -98,8 +99,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       // 'type' // parsing manually below to avoid conflict with côte requester 'type'

--- a/src/routes/message.js
+++ b/src/routes/message.js
@@ -21,8 +21,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'createdDate',

--- a/src/routes/order.js
+++ b/src/routes/order.js
@@ -46,8 +46,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'payerId',

--- a/src/routes/task.js
+++ b/src/routes/task.js
@@ -20,8 +20,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'eventType',

--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -21,8 +21,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'createdDate',

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -42,8 +42,14 @@ function init (server, { middlewares, helpers } = {}) {
     const fields = [
       'orderBy',
       'order',
-      'page',
       'nbResultsPerPage',
+
+      // offset pagination
+      'page',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
 
       'id',
       'createdDate',

--- a/src/services/apiKey.js
+++ b/src/services/apiKey.js
@@ -63,8 +63,14 @@ function start ({ communication, isSystem }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -109,13 +115,20 @@ function start ({ communication, isSystem }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     const options = {}

--- a/src/services/assessment.js
+++ b/src/services/assessment.js
@@ -64,8 +64,14 @@ function start ({ communication }) {
     const {
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       assetId
     } = req
@@ -84,13 +90,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = paginationMeta.results.map(assessment => {

--- a/src/services/asset.js
+++ b/src/services/asset.js
@@ -89,8 +89,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -178,13 +184,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     const indexedDynamicNamespaces = await namespaceRequester.send({

--- a/src/services/availability.js
+++ b/src/services/availability.js
@@ -143,8 +143,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       assetId
     } = req
@@ -175,13 +181,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = Availability.exposeAll(paginationMeta.results, { req })

--- a/src/services/customAttribute.js
+++ b/src/services/customAttribute.js
@@ -70,8 +70,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id
     } = req
@@ -90,13 +96,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = CustomAttribute.exposeAll(paginationMeta.results, { req })

--- a/src/services/document.js
+++ b/src/services/document.js
@@ -355,7 +355,6 @@ function start ({ communication }) {
             queryBuilder,
             nbResultsPerPage,
             page,
-            applyOrder: false,
           })
         } else {
           const cursorProps = [

--- a/src/services/document.js
+++ b/src/services/document.js
@@ -358,11 +358,11 @@ function start ({ communication }) {
             applyOrder: false,
           })
         } else {
-          const cursorConfig = [
+          const cursorProps = [
             // In most cases, it is the type string (`authorId` and `targetId`)
             // but we cannot be sure as users can provide any field via `data.prop`
             // TODO: maybe perform a request to retrieve a row with the existing prop
-            { prop: 'groupByField', type: 'string' },
+            { name: 'groupByField', type: 'string' },
           ]
 
           paginationMeta = await cursorPaginate({
@@ -370,7 +370,7 @@ function start ({ communication }) {
             nbResultsPerPage,
             startingAfter,
             endingBefore,
-            cursorConfig,
+            cursorProps,
           })
         }
 

--- a/src/services/document.js
+++ b/src/services/document.js
@@ -9,10 +9,8 @@ const { performListQuery } = require('../util/listQueryBuilder')
 
 const _ = require('lodash')
 
-const {
-  getPaginationMeta,
-  parseArrayValues
-} = require('../util/list')
+const { getPaginationMeta } = require('../util/pagination')
+const { parseArrayValues } = require('../util/list')
 
 let responder
 

--- a/src/services/entry.js
+++ b/src/services/entry.js
@@ -51,8 +51,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       collection,
@@ -92,13 +98,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = Entry.exposeAll(paginationMeta.results, { req })

--- a/src/services/event.js
+++ b/src/services/event.js
@@ -23,9 +23,9 @@ function start ({ communication }) {
 
     const {
       order,
-
-      page,
       nbResultsPerPage,
+      startingAfter,
+      endingBefore,
 
       groupBy,
 
@@ -97,13 +97,14 @@ function start ({ communication }) {
         }
       },
       paginationConfig: {
-        page,
-        nbResultsPerPage
+        nbResultsPerPage,
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy: groupBy,
         order
-      }
+      },
     })
 
     return paginationMeta
@@ -223,8 +224,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -298,13 +305,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = Event.exposeAll(paginationMeta.results, { req })

--- a/src/services/message.js
+++ b/src/services/message.js
@@ -53,8 +53,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -116,13 +122,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     const currentUserId = getCurrentUserId(req)

--- a/src/services/order.js
+++ b/src/services/order.js
@@ -108,8 +108,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       payerId,
@@ -171,13 +177,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = paginationMeta.results.map(order => Order.expose(order, { req }))

--- a/src/services/task.js
+++ b/src/services/task.js
@@ -55,8 +55,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -106,13 +112,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = Task.exposeAll(paginationMeta.results, { req })

--- a/src/services/transaction.js
+++ b/src/services/transaction.js
@@ -102,8 +102,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -208,13 +214,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     paginationMeta.results = Transaction.exposeAll(paginationMeta.results, { req })

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -100,8 +100,14 @@ function start ({ communication }) {
       orderBy,
       order,
 
-      page,
       nbResultsPerPage,
+
+      // offset pagination
+      page,
+
+      // cursor pagination
+      startingAfter,
+      endingBefore,
 
       id,
       createdDate,
@@ -174,13 +180,20 @@ function start ({ communication }) {
       },
       paginationActive: true,
       paginationConfig: {
+        nbResultsPerPage,
+
+        // offset pagination
         page,
-        nbResultsPerPage
+
+        // cursor pagination
+        startingAfter,
+        endingBefore,
       },
       orderConfig: {
         orderBy,
         order
-      }
+      },
+      useOffsetPagination: req._useOffsetPagination,
     })
 
     const currentUserId = getCurrentUserId(req)

--- a/src/util/cursor.js
+++ b/src/util/cursor.js
@@ -17,11 +17,11 @@ const separator = '~|~'
 const nullValue = '[[NULL]]' // to distinguish from string with 'null' value
 const undefinedValue = '[[UNDEFINED]]' // to distinguish from string with 'undefined' value
 
-function isValidCursorConfig (config) {
-  return Array.isArray(config) &&
-    config.length > 0 &&
-    config.length <= 2 &&
-    config.every(c => _.isString(c.prop) && allowedTypes.includes(c.type))
+function isValidCursorProps (props) {
+  return Array.isArray(props) &&
+    props.length > 0 &&
+    props.length <= 2 &&
+    props.every(p => _.isString(p.name) && allowedTypes.includes(p.type))
 }
 
 /**
@@ -30,18 +30,18 @@ function isValidCursorConfig (config) {
  * Example: (createdDate) isn't enough because two rows can have the same value
  * then (createdDate, id) is a good candidate for cursor
  * @param {Object}   obj - cursor will be created based on this object
- * @param {Object[]} config
- * @param {Object}   config[i]
- * @param {String}   config[i].prop - object property to encode
- * @param {String}   config[i].type - allowed value: 'number', 'boolean', 'date', 'string'
+ * @param {Object[]} props
+ * @param {Object}   props[i]
+ * @param {String}   props[i].name - prop name to encode
+ * @param {String}   props[i].type - allowed value: 'number', 'boolean', 'date', 'string'
  */
-function createCursor (obj, config) {
-  if (!config) throw new Error('Missing cursor config')
-  if (!isValidCursorConfig(config)) throw new Error('Invalid cursor config')
+function createCursor (obj, props) {
+  if (!props) throw new Error('Missing cursor props')
+  if (!isValidCursorProps(props)) throw new Error('Invalid cursor props')
 
-  const cursor = config.map(c => {
-    const { prop } = c
-    return stringifyValue(obj[prop])
+  const cursor = props.map(p => {
+    const { name } = p
+    return stringifyValue(obj[name])
   }).join(separator)
 
   return encodeBase64(cursor)
@@ -49,24 +49,24 @@ function createCursor (obj, config) {
 
 /**
  * @param {Object}   obj - cursor will be created based on this object
- * @param {Object[]} config
- * @param {Object}   config[i]
- * @param {String}   config[i].prop - object property
- * @param {String}   config[i].type - allowed value: 'number', 'boolean', 'date', 'string'
+ * @param {Object[]} props
+ * @param {Object}   props[i]
+ * @param {String}   props[i].name - object property
+ * @param {String}   props[i].type - allowed value: 'number', 'boolean', 'date', 'string'
  */
-function parseCursor (cursor, config) {
-  if (!config) throw new Error('Missing cursor config')
-  if (!isValidCursorConfig(config)) throw new Error('Invalid cursor config')
+function parseCursor (cursor, props) {
+  if (!props) throw new Error('Missing cursor props')
+  if (!isValidCursorProps(props)) throw new Error('Invalid cursor props')
 
   const parts = decodeBase64(cursor).split(separator)
-  if (parts.length !== config.length) throw new Error('Invalid cursor')
+  if (parts.length !== props.length) throw new Error('Invalid cursor')
 
   return parts.reduce((decoded, p, index) => {
-    const { prop, type } = config[index]
+    const { name, type } = props[index]
 
     return {
       ...decoded,
-      [prop]: parseValue(p, type)
+      [name]: parseValue(p, type)
     }
   }, {})
 }
@@ -87,7 +87,7 @@ function parseValue (value, type) {
 }
 
 module.exports = {
-  isValidCursorConfig,
+  isValidCursorProps,
   createCursor,
   parseCursor,
 }

--- a/src/util/cursor.js
+++ b/src/util/cursor.js
@@ -1,0 +1,93 @@
+const _ = require('lodash')
+const { encodeBase64, decodeBase64 } = require('./encoding')
+
+const allowedTypes = [
+  'number',
+  'boolean',
+  'string',
+
+  // Date instances are returned from database for timestamptz type
+  // which is different from date stored in string type
+  'date',
+]
+
+// must be uncommon chain of characters to distinguish
+// from real string values
+const separator = '~|~'
+const nullValue = '[[NULL]]' // to distinguish from string with 'null' value
+const undefinedValue = '[[UNDEFINED]]' // to distinguish from string with 'undefined' value
+
+function isValidCursorConfig (config) {
+  return Array.isArray(config) &&
+    config.length > 0 &&
+    config.length <= 2 &&
+    config.every(c => _.isString(c.prop) && allowedTypes.includes(c.type))
+}
+
+/**
+ * A cursor encodes one or two values.
+ * If unicity isn't guaranteed by one value, provide two values.
+ * Example: (createdDate) isn't enough because two rows can have the same value
+ * then (createdDate, id) is a good candidate for cursor
+ * @param {Object}   obj - cursor will be created based on this object
+ * @param {Object[]} config
+ * @param {Object}   config[i]
+ * @param {String}   config[i].prop - object property to encode
+ * @param {String}   config[i].type - allowed value: 'number', 'boolean', 'date', 'string'
+ */
+function createCursor (obj, config) {
+  if (!config) throw new Error('Missing cursor config')
+  if (!isValidCursorConfig(config)) throw new Error('Invalid cursor config')
+
+  const cursor = config.map(c => {
+    const { prop } = c
+    return stringifyValue(obj[prop])
+  }).join(separator)
+
+  return encodeBase64(cursor)
+}
+
+/**
+ * @param {Object}   obj - cursor will be created based on this object
+ * @param {Object[]} config
+ * @param {Object}   config[i]
+ * @param {String}   config[i].prop - object property
+ * @param {String}   config[i].type - allowed value: 'number', 'boolean', 'date', 'string'
+ */
+function parseCursor (cursor, config) {
+  if (!config) throw new Error('Missing cursor config')
+  if (!isValidCursorConfig(config)) throw new Error('Invalid cursor config')
+
+  const parts = decodeBase64(cursor).split(separator)
+  if (parts.length !== config.length) throw new Error('Invalid cursor')
+
+  return parts.reduce((decoded, p, index) => {
+    const { prop, type } = config[index]
+
+    return {
+      ...decoded,
+      [prop]: parseValue(p, type)
+    }
+  }, {})
+}
+
+function stringifyValue (value) {
+  if (_.isUndefined(value)) return undefinedValue
+  if (_.isNull(value)) return nullValue
+  if (value instanceof Date) return value.toISOString()
+  return String(value)
+}
+
+function parseValue (value, type) {
+  if (value === undefinedValue) return
+  if (value === nullValue) return null
+  if (type === 'number') return parseFloat(value)
+  if (type === 'boolean') return value === 'true'
+  return value
+}
+
+module.exports = {
+  isValidCursorConfig,
+  createCursor,
+  parseCursor,
+}

--- a/src/util/cursor.js
+++ b/src/util/cursor.js
@@ -6,7 +6,7 @@ const allowedTypes = [
   'boolean',
   'string',
 
-  // Date instances are returned from database for timestamptz type
+  // This refers to timestamptz dates returned from PostgreSQL
   // which is different from date stored in string type
   'date',
 ]

--- a/src/util/list.js
+++ b/src/util/list.js
@@ -1,27 +1,8 @@
 module.exports = {
 
-  getPaginationMeta,
   parseArrayValues,
   replaceBy,
 
-  DEFAULT_NB_RESULTS_PER_PAGE: 20
-
-}
-
-function getPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
-  let nbPages = Math.floor(nbResults / nbResultsPerPage)
-  if (nbResults % nbResultsPerPage !== 0) {
-    nbPages += 1
-  }
-
-  const paginationMeta = {
-    nbResults,
-    nbPages,
-    page,
-    nbResultsPerPage
-  }
-
-  return paginationMeta
 }
 
 function parseArrayValues (values) {

--- a/src/util/list.js
+++ b/src/util/list.js
@@ -8,18 +8,7 @@ module.exports = {
 
 }
 
-function getPaginationMeta ({ nbResults, page, nbResultsPerPage, allResults = false }) {
-  if (allResults) {
-    const paginationMeta = {
-      nbResults,
-      nbPages: 1,
-      page: 1,
-      nbResultsPerPage: null
-    }
-
-    return paginationMeta
-  }
-
+function getPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
   let nbPages = Math.floor(nbResults / nbResultsPerPage)
   if (nbResults % nbResultsPerPage !== 0) {
     nbPages += 1

--- a/src/util/listQueryBuilder.js
+++ b/src/util/listQueryBuilder.js
@@ -292,9 +292,9 @@ async function performListQuery ({
       const { orderBy, order, orderType } = orderConfig
       const { nbResultsPerPage, startingAfter, endingBefore } = paginationConfig
 
-      const cursorConfig = [
-        { prop: orderBy, type: orderType || 'string' },
-        { prop: 'id', type: 'string' },
+      const cursorProps = [
+        { name: orderBy, type: orderType || 'string' },
+        { name: 'id', type: 'string' },
       ]
 
       return cursorPaginate({
@@ -302,7 +302,7 @@ async function performListQuery ({
         startingAfter,
         endingBefore,
         order,
-        cursorConfig,
+        cursorProps,
         nbResultsPerPage,
       })
     }
@@ -642,8 +642,8 @@ async function performHistoryQuery ({
   const { orderBy, order } = orderConfig
   const { nbResultsPerPage, startingAfter, endingBefore } = paginationConfig
 
-  const cursorConfig = [
-    { prop: orderBy, type: 'date' },
+  const cursorProps = [
+    { name: orderBy, type: 'date' },
   ]
 
   return cursorPaginate({
@@ -651,7 +651,7 @@ async function performHistoryQuery ({
     startingAfter,
     endingBefore,
     order,
-    cursorConfig,
+    cursorProps,
     nbResultsPerPage,
   })
 }

--- a/src/util/listQueryBuilder.js
+++ b/src/util/listQueryBuilder.js
@@ -2,7 +2,8 @@ const _ = require('lodash')
 const createError = require('http-errors')
 
 const { Joi } = require('./validation')
-const { parseArrayValues, getPaginationMeta } = require('./list')
+const { getPaginationMeta } = require('./pagination')
+const { parseArrayValues } = require('./list')
 const { roundDecimal } = require('./math')
 
 const filtersSchema = Joi.object().pattern(

--- a/src/util/math.js
+++ b/src/util/math.js
@@ -1,3 +1,21 @@
+const Big = require('big.js')
+
+// Classic native JS sum has floating precision issues:
+// Basic sum: 8.1 + 8.2 = 16.299999999999997
+
+// Transitive issue:
+// 8.3 + 8.7 + 8 + 8.1 = 33.1
+// 8 + 8.7 + 8.1 + 8.3 = 33.099999999999994
+function sumDecimals (numbers, precision = 10) {
+  return parseFloat(
+    numbers
+      .reduce(
+        (big, n) => big.add(n),
+        Big(0)
+      ).toFixed(precision)
+  )
+}
+
 // Do not use "classic" rounding method (e.g `Math.round(8.325 * 100) / 100 === 8.32`)
 // Instead use a more accurate rounding with exponential notation (e.g `Number(Math.round(8.325 + 'e2') + 'e-2') === 8.33`)
 // https://www.jacklmoore.com/notes/rounding-in-javascript/
@@ -6,5 +24,6 @@ function roundDecimal (number, precision, customFn = Math.round) {
 }
 
 module.exports = {
+  sumDecimals,
   roundDecimal
 }

--- a/src/util/pagination.js
+++ b/src/util/pagination.js
@@ -1,0 +1,21 @@
+function getPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
+  let nbPages = Math.floor(nbResults / nbResultsPerPage)
+  if (nbResults % nbResultsPerPage !== 0) {
+    nbPages += 1
+  }
+
+  const paginationMeta = {
+    nbResults,
+    nbPages,
+    page,
+    nbResultsPerPage
+  }
+
+  return paginationMeta
+}
+
+module.exports = {
+  getPaginationMeta,
+
+  DEFAULT_NB_RESULTS_PER_PAGE: 20,
+}

--- a/src/util/pagination.js
+++ b/src/util/pagination.js
@@ -1,3 +1,33 @@
+const _ = require('lodash')
+const createError = require('http-errors')
+const { createCursor, parseCursor } = require('./cursor')
+
+const reverseOrder = (order) => order === 'asc' ? 'desc' : 'asc'
+const reverseOperator = (operator) => {
+  // reverse the order, not negate the operator
+  // negation of '>' is '<='
+  const map = {
+    '>': '<',
+    '>=': '<=',
+    '<': '>',
+    '<=': '>=',
+  }
+
+  return map[operator]
+}
+
+const matchCursorResult = _.curry((decodedCursor, result) => {
+  const normalizeValue = prop => prop instanceof Date ? prop.toISOString() : prop
+
+  return Object.keys(decodedCursor).every(k => {
+    return normalizeValue(result[k]) === normalizeValue(decodedCursor[k])
+  })
+})
+
+// ///////////////// //
+// OFFSET PAGINATION //
+// ///////////////// //
+
 function getOffsetPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
   let nbPages = Math.floor(nbResults / nbResultsPerPage)
   if (nbResults % nbResultsPerPage !== 0) {
@@ -51,9 +81,177 @@ async function offsetPaginate ({
   return paginationMeta
 }
 
+// ///////////////// //
+// CURSOR PAGINATION //
+// ///////////////// //
+
+/**
+ * @param {Object}   queryBuilder - Knex.js query builder
+ *
+ * `startingAfter` and `endingBefore` are mutually exclusive
+ * @param {String}   [startingAfter] - if specified, fetch results after this cursor
+ * @param {String}   [endingBefore] - if specified, fetch results before this cursor
+ *
+ * @param {Number}   nbResultsPerPage
+ *
+ * @param {Object[]} cursorConfig - will be used to create/parse cursor
+ * @param {Object}   cursorConfig[i]
+ * @param {String}   cursorConfig[i].prop - object property to encode
+ * @param {String}   cursorConfig[i].type - allowed value: 'number', 'boolean', 'date', 'string'
+ *
+ * @param {String}   order - allowed values: 'asc', 'desc'
+ */
+async function cursorPaginate ({
+  queryBuilder,
+  startingAfter,
+  endingBefore,
+  nbResultsPerPage,
+  cursorConfig,
+  order,
+}) {
+  // if `endingBefore` is specified, this is equivalent to retrieving
+  // the `nbResultsPerPage` last results.
+  // To achieve it, this is done with 2 steps:
+  // 1. reverse the `order` direction for the SQL query with limit to `nbResultsPerPage`
+  // 2. reverse the obtained results in Javascript
+  const shouldReverseOrder = !!endingBefore
+
+  const cursor = startingAfter || endingBefore
+  let decodedCursor
+
+  try {
+    if (cursor) {
+      decodedCursor = parseCursor(cursor, cursorConfig)
+
+      queryBuilder = applyCursorPaginationParameters({
+        queryBuilder,
+        cursorConfig,
+        decodedCursor,
+        order,
+        shouldReverseOrder,
+      })
+    }
+  } catch (err) {
+    throw createError(422, 'Invalid cursor')
+  }
+
+  queryBuilder.orderBy(
+    cursorConfig.map(c => ({
+      column: c.prop,
+      order: shouldReverseOrder ? reverseOrder(order) : order
+    }))
+  )
+
+  // adds 2 to the limit to try to retrieve 1 result from previous and next pages
+  let results = await queryBuilder.limit(nbResultsPerPage + 2)
+
+  const paginationMeta = getCursorPaginationMeta({
+    decodedCursor,
+    results,
+    startingAfter,
+    endingBefore,
+    nbResultsPerPage,
+  })
+
+  // remove cursor result
+  if (decodedCursor) results = results.filter(_.negate(matchCursorResult(decodedCursor)))
+
+  results = results.slice(0, nbResultsPerPage)
+  if (shouldReverseOrder) results = results.reverse()
+
+  const firstResult = _.first(results)
+  const lastResult = _.last(results)
+
+  paginationMeta.startCursor = firstResult ? createCursor(firstResult, cursorConfig) : null
+  paginationMeta.endCursor = lastResult ? createCursor(lastResult, cursorConfig) : null
+
+  paginationMeta.results = results
+  return paginationMeta
+}
+
+function getCursorPaginationMeta ({
+  decodedCursor,
+  results,
+  startingAfter,
+  endingBefore,
+  nbResultsPerPage,
+}) {
+  let hasPreviousPage = false
+  let hasNextPage = false
+
+  if (decodedCursor) {
+    const matchingResult = matchCursorResult(decodedCursor)
+
+    const cursorResult = results.find(matchingResult)
+    const resultsWithoutCursorResult = results.filter(_.negate(matchingResult))
+
+    if (startingAfter) {
+      hasPreviousPage = Boolean(cursorResult)
+      hasNextPage = resultsWithoutCursorResult.length > nbResultsPerPage
+    } else if (endingBefore) {
+      hasPreviousPage = resultsWithoutCursorResult.length > nbResultsPerPage
+      hasNextPage = Boolean(cursorResult)
+    }
+  } else {
+    if (endingBefore) hasPreviousPage = results.length > nbResultsPerPage
+    else hasNextPage = results.length > nbResultsPerPage
+  }
+
+  return {
+    hasPreviousPage,
+    hasNextPage,
+    nbResultsPerPage,
+  }
+}
+
+function applyCursorPaginationParameters ({
+  queryBuilder,
+  cursorConfig,
+  decodedCursor,
+  order,
+  shouldReverseOrder,
+}) {
+  return queryBuilder
+    .where(qb => {
+      const firstProp = cursorConfig[0].prop
+      const secondaryProp = cursorConfig.length === 2 ? cursorConfig[1].prop : null
+
+      let operator = order === 'asc' ? '>' : '<'
+      let operatorWithEqual = order === 'asc' ? '>=' : '<='
+
+      if (shouldReverseOrder) {
+        operator = reverseOperator(operator)
+        operatorWithEqual = reverseOperator(operatorWithEqual)
+      }
+
+      if (cursorConfig.length === 1) {
+        // if one-column cursor
+        // use operator with equal to include the cursor result
+        // to determine if there is a previous page
+        qb.where(firstProp, operatorWithEqual, decodedCursor[firstProp])
+      } else {
+        qb
+          .where(firstProp, operator, decodedCursor[firstProp])
+          .orWhere(qb2 => {
+            // if two-columns cursor
+            // use operator with equal on the secondary column to include the cursor result
+            // to determine if there is a previous page
+            return qb2
+              .where(firstProp, decodedCursor[firstProp])
+              .where(secondaryProp, operatorWithEqual, decodedCursor[secondaryProp])
+          })
+      }
+
+      return qb
+    })
+}
+
 module.exports = {
   offsetPaginate,
   getOffsetPaginationMeta,
+
+  cursorPaginate,
+  getCursorPaginationMeta,
 
   DEFAULT_NB_RESULTS_PER_PAGE: 20,
 }

--- a/src/util/pagination.js
+++ b/src/util/pagination.js
@@ -1,4 +1,4 @@
-function getPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
+function getOffsetPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
   let nbPages = Math.floor(nbResults / nbResultsPerPage)
   if (nbResults % nbResultsPerPage !== 0) {
     nbPages += 1
@@ -14,8 +14,46 @@ function getPaginationMeta ({ nbResults, page, nbResultsPerPage }) {
   return paginationMeta
 }
 
+async function offsetPaginate ({
+  queryBuilder,
+  orderBy,
+  order,
+  nbResultsPerPage,
+  page,
+  applyOrder = true,
+}) {
+  // Clone the query builder to have the count for all matched results before pagination filtering
+  const countQueryBuilder = queryBuilder.clone()
+
+  if (applyOrder) {
+    queryBuilder.orderBy(orderBy, order)
+  }
+
+  queryBuilder
+    .offset((page - 1) * nbResultsPerPage)
+    .limit(nbResultsPerPage)
+
+  const [
+    results,
+    [{ count: nbResults }]
+  ] = await Promise.all([
+    queryBuilder,
+    countQueryBuilder.count()
+  ])
+
+  const paginationMeta = getOffsetPaginationMeta({
+    nbResults,
+    nbResultsPerPage,
+    page
+  })
+
+  paginationMeta.results = results
+  return paginationMeta
+}
+
 module.exports = {
-  getPaginationMeta,
+  offsetPaginate,
+  getOffsetPaginationMeta,
 
   DEFAULT_NB_RESULTS_PER_PAGE: 20,
 }

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -160,6 +160,16 @@ const searchSchema = customJoi.object().keys({
   createdAfter: customJoi.string().isoDate().allow(null)
 })
 
+function replaceOffsetWithCursorPagination (schema) {
+  return schema
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      startingAfter: customJoi.string(),
+      endingBefore: customJoi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+}
+
 module.exports = {
   Joi: customJoi,
   isUUIDV4,
@@ -167,5 +177,6 @@ module.exports = {
 
   objectIdParamsSchema,
   searchSchema,
-  getRangeFilter
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
 }

--- a/src/versions/request/beforeAll.js
+++ b/src/versions/request/beforeAll.js
@@ -1,0 +1,17 @@
+const requestChanges = {
+  '2019-05-20': [
+    {
+      target: 'beforeAll', // all requests with a version <= '2019-05-20'
+      description: 'Use offset pagination for version below version 2019-05-20 included',
+      up: async (params) => {
+        const { req } = params
+
+        req._useOffsetPagination = true
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = requestChanges

--- a/src/versions/request/index.js
+++ b/src/versions/request/index.js
@@ -2,7 +2,7 @@ const VersionTransformer = require('../transformer')
 const { apiVersions, transformConfigsIntoChanges } = require('../util')
 
 const listRequestChangeConfigs = [
-
+  require('./beforeAll'),
 ]
 
 const changes = transformConfigsIntoChanges(listRequestChangeConfigs)

--- a/src/versions/validation/apiKey.js
+++ b/src/versions/validation/apiKey.js
@@ -4,6 +4,11 @@ const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/valida
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
+  'createdDate',
+  'updatedDate',
+]
+
+const oldPaginationOrderByFields = [
   'name',
   'createdDate',
   'updatedDate'
@@ -33,13 +38,29 @@ const rightsSchema = Joi.when('type', {
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
 schemas['2019-05-20'].list = {
   query: Joi.object().keys({
     // order
-    orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+    orderBy: Joi.string().valid(...oldPaginationOrderByFields).default('createdDate'),
     order: Joi.string().valid('asc', 'desc').default('desc'),
 
     // pagination
@@ -82,6 +103,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'apiKey.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'apiKey.list',

--- a/src/versions/validation/apiKey.js
+++ b/src/versions/validation/apiKey.js
@@ -1,7 +1,7 @@
 const { builtInTypes, customTypeRegex } = require('stelace-util-keys')
 
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'name',

--- a/src/versions/validation/apiKey.js
+++ b/src/versions/validation/apiKey.js
@@ -1,6 +1,11 @@
 const { builtInTypes, customTypeRegex } = require('stelace-util-keys')
 
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -42,15 +47,10 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(
+    schemas['2019-05-20'].list.query
+      .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+  )
 })
 
 // ////////// //

--- a/src/versions/validation/assessment.js
+++ b/src/versions/validation/assessment.js
@@ -23,6 +23,21 @@ const signCodesSchema = Joi.object().pattern(
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -76,6 +91,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'assessment.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'assessment.list',

--- a/src/versions/validation/assessment.js
+++ b/src/versions/validation/assessment.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const signersSchema = Joi.object().pattern(
   Joi.string().required(),

--- a/src/versions/validation/assessment.js
+++ b/src/versions/validation/assessment.js
@@ -1,4 +1,8 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const signersSchema = Joi.object().pattern(
@@ -27,14 +31,7 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/asset.js
+++ b/src/versions/validation/asset.js
@@ -1,4 +1,9 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const locationSchema = Joi.object().unknown().keys({
@@ -28,15 +33,10 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(
+    schemas['2019-05-20'].list.query
+      .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+  )
 })
 
 // ////////// //

--- a/src/versions/validation/asset.js
+++ b/src/versions/validation/asset.js
@@ -7,6 +7,11 @@ const locationSchema = Joi.object().unknown().keys({
 })
 
 const orderByFields = [
+  'createdDate',
+  'updatedDate',
+]
+
+const oldPaginationOrderByFields = [
   'name',
   'createdDate',
   'updatedDate',
@@ -19,13 +24,29 @@ const orderByFields = [
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
 schemas['2019-05-20'].list = {
   query: Joi.object().keys({
     // order
-    orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+    orderBy: Joi.string().valid(...oldPaginationOrderByFields).default('createdDate'),
     order: Joi.string().valid('asc', 'desc').default('desc'),
 
     // pagination
@@ -77,6 +98,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'asset.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'asset.list',

--- a/src/versions/validation/asset.js
+++ b/src/versions/validation/asset.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const locationSchema = Joi.object().unknown().keys({
   latitude: Joi.number().min(-90).max(90).required(),

--- a/src/versions/validation/availability.js
+++ b/src/versions/validation/availability.js
@@ -1,4 +1,8 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 const { allowedTimeUnits } = require('../../util/time')
 
@@ -25,14 +29,7 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/availability.js
+++ b/src/versions/validation/availability.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 const { allowedTimeUnits } = require('../../util/time')
 
 const durationSchema = Joi.object().pattern(

--- a/src/versions/validation/availability.js
+++ b/src/versions/validation/availability.js
@@ -21,6 +21,21 @@ const orderByFields = [
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -67,6 +82,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'availability.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'availability.getGraph',

--- a/src/versions/validation/customAttribute.js
+++ b/src/versions/validation/customAttribute.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'name',

--- a/src/versions/validation/customAttribute.js
+++ b/src/versions/validation/customAttribute.js
@@ -1,4 +1,8 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -19,15 +23,10 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(
+    schemas['2019-05-20'].list.query
+      .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+  )
 })
 
 // ////////// //

--- a/src/versions/validation/customAttribute.js
+++ b/src/versions/validation/customAttribute.js
@@ -2,6 +2,11 @@ const { Joi, objectIdParamsSchema } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
+  'createdDate',
+  'updatedDate'
+]
+
+const oldPaginationOrderByFields = [
   'name',
   'createdDate',
   'updatedDate'
@@ -10,13 +15,29 @@ const orderByFields = [
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
 schemas['2019-05-20'].list = {
   query: Joi.object().keys({
     // order
-    orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+    orderBy: Joi.string().valid(...oldPaginationOrderByFields).default('createdDate'),
     order: Joi.string().valid('asc', 'desc').default('desc'),
 
     // pagination
@@ -49,6 +70,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'customAttribute.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'customAttribute.list',

--- a/src/versions/validation/document.js
+++ b/src/versions/validation/document.js
@@ -1,4 +1,8 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -24,24 +28,10 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].getStats = () => ({
-  query: schemas['2019-05-20'].getStats.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].getStats.query)
 })
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/document.js
+++ b/src/versions/validation/document.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'createdDate',

--- a/src/versions/validation/document.js
+++ b/src/versions/validation/document.js
@@ -20,6 +20,31 @@ const multipleLabelsWithWildcardSchema = Joi.string().regex(/^(\*|(\w+)(:(\w+|\*
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].getStats = () => ({
+  query: schemas['2019-05-20'].getStats.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -93,6 +118,17 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'document.getStats',
+      schema: schemas['2020-08-10'].getStats
+    },
+    {
+      target: 'document.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'document.getStats',

--- a/src/versions/validation/entry.js
+++ b/src/versions/validation/entry.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'createdDate',

--- a/src/versions/validation/entry.js
+++ b/src/versions/validation/entry.js
@@ -11,6 +11,21 @@ const localeSchema = Joi.string().regex(/^[a-z_-]+$/i).max(255)
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -54,6 +69,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'entry.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'entry.list',

--- a/src/versions/validation/entry.js
+++ b/src/versions/validation/entry.js
@@ -1,4 +1,8 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -15,14 +19,7 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -1,4 +1,9 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -66,15 +71,10 @@ schemas['2020-08-10'].getHistory = {
   })
 }
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(
+    schemas['2019-05-20'].list.query
+      .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+  )
 })
 
 // ////////// //

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'name',

--- a/src/versions/validation/index.js
+++ b/src/versions/validation/index.js
@@ -112,7 +112,11 @@ const middleware = () => {
       return setImmediate(next)
     }
 
-    const { schema } = validationDefinition
+    const { schema: schemaObjOrFunction } = validationDefinition
+
+    let schema
+    if (_.isFunction(schemaObjOrFunction)) schema = schemaObjOrFunction()
+    else schema = schemaObjOrFunction
 
     const toValidate = keysToValidate.reduce((accum, key) => {
       // only include keys present in the validation object

--- a/src/versions/validation/message.js
+++ b/src/versions/validation/message.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'createdDate',

--- a/src/versions/validation/message.js
+++ b/src/versions/validation/message.js
@@ -1,4 +1,9 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -13,14 +18,7 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/message.js
+++ b/src/versions/validation/message.js
@@ -9,6 +9,21 @@ const orderByFields = [
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -66,6 +81,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'message.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'message.list',

--- a/src/versions/validation/order.js
+++ b/src/versions/validation/order.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'createdDate',

--- a/src/versions/validation/order.js
+++ b/src/versions/validation/order.js
@@ -1,4 +1,8 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -51,14 +55,7 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/order.js
+++ b/src/versions/validation/order.js
@@ -47,6 +47,21 @@ const moveSchema = Joi.object()
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -138,6 +153,13 @@ schemas['2019-05-20'].updateMove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'order.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'order.preview',

--- a/src/versions/validation/task.js
+++ b/src/versions/validation/task.js
@@ -1,4 +1,9 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -23,15 +28,10 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(
+    schemas['2019-05-20'].list.query
+      .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+  )
 })
 
 // ////////// //

--- a/src/versions/validation/task.js
+++ b/src/versions/validation/task.js
@@ -2,6 +2,11 @@ const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/valida
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
+  'createdDate',
+  'updatedDate',
+]
+
+const oldPaginationOrderByFields = [
   'name',
   'createdDate',
   'updatedDate',
@@ -14,13 +19,29 @@ const orderByFields = [
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
 schemas['2019-05-20'].list = {
   query: Joi.object().keys({
     // order
-    orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+    orderBy: Joi.string().valid(...oldPaginationOrderByFields).default('createdDate'),
     order: Joi.string().valid('asc', 'desc').default('desc'),
 
     // pagination
@@ -62,6 +83,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'task.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'task.list',

--- a/src/versions/validation/task.js
+++ b/src/versions/validation/task.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
   'name',

--- a/src/versions/validation/transaction.js
+++ b/src/versions/validation/transaction.js
@@ -15,6 +15,21 @@ const durationSchema = Joi.object().pattern(
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -94,6 +109,13 @@ schemas['2019-05-20'].createTransition = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'transaction.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'transaction.preview',

--- a/src/versions/validation/transaction.js
+++ b/src/versions/validation/transaction.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 const { allowedTimeUnits } = require('../../util/time')
 
 const orderByFields = [

--- a/src/versions/validation/transaction.js
+++ b/src/versions/validation/transaction.js
@@ -1,4 +1,9 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 const { allowedTimeUnits } = require('../../util/time')
 
@@ -19,14 +24,7 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(schemas['2019-05-20'].list.query)
 })
 
 // ////////// //

--- a/src/versions/validation/user.js
+++ b/src/versions/validation/user.js
@@ -1,4 +1,9 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const {
+  Joi,
+  objectIdParamsSchema,
+  getRangeFilter,
+  replaceOffsetWithCursorPagination,
+} = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const organizationSchema = Joi.object().pattern(
@@ -44,15 +49,10 @@ const schemas = {}
 // ////////// //
 schemas['2020-08-10'] = {}
 schemas['2020-08-10'].list = () => ({
-  query: schemas['2019-05-20'].list.query
-    .fork('page', schema => schema.forbidden())
-    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
-    .keys({
-      // cursor pagination
-      startingAfter: Joi.string(),
-      endingBefore: Joi.string(),
-    })
-    .oxor('startingAfter', 'endingBefore')
+  query: replaceOffsetWithCursorPagination(
+    schemas['2019-05-20'].list.query
+      .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+  )
 })
 
 // ////////// //

--- a/src/versions/validation/user.js
+++ b/src/versions/validation/user.js
@@ -9,6 +9,11 @@ const organizationSchema = Joi.object().pattern(
 )
 
 const orderByFields = [
+  'createdDate',
+  'updatedDate'
+]
+
+const oldPaginationOrderByFields = [
   'name',
   'createdDate',
   'updatedDate'
@@ -35,6 +40,22 @@ const usernameOrPasswordSchema = Joi.string().alter({
 const schemas = {}
 
 // ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = () => ({
+  query: schemas['2019-05-20'].list.query
+    .fork('page', schema => schema.forbidden())
+    .fork('orderBy', () => Joi.string().valid(...orderByFields).default('createdDate'))
+    .keys({
+      // cursor pagination
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+})
+
+// ////////// //
 // 2019-05-20 //
 // ////////// //
 schemas['2019-05-20'] = {}
@@ -46,7 +67,7 @@ schemas['2019-05-20'].checkAvailability = {
 schemas['2019-05-20'].list = {
   query: Joi.object().keys({
     // order
-    orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+    orderBy: Joi.string().valid(...oldPaginationOrderByFields).default('createdDate'),
     order: Joi.string().valid('asc', 'desc').default('desc'),
 
     // pagination
@@ -109,6 +130,13 @@ schemas['2019-05-20'].removeFromOrganization = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'user.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'user.checkAvailability',

--- a/src/versions/validation/user.js
+++ b/src/versions/validation/user.js
@@ -1,5 +1,5 @@
 const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
-const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/list')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const organizationSchema = Joi.object().pattern(
   Joi.string(),

--- a/test/auth.js
+++ b/test/auth.js
@@ -10,6 +10,7 @@ async function getAccessTokenHeaders ({
   permissions = [],
   readNamespaces = [],
   editNamespaces = [],
+  apiVersion,
   t
 }) {
   const accessToken = await getAccessToken({
@@ -19,12 +20,18 @@ async function getAccessTokenHeaders ({
     editNamespaces
   })
 
-  return {
+  const headers = {
     authorization: `Bearer ${accessToken}`,
     // TODO: use an API key instead of these special headers
     'x-platform-id': t.context.platformId,
     'x-stelace-env': t.context.env
   }
+
+  if (apiVersion) {
+    headers['x-stelace-version'] = apiVersion
+  }
+
+  return headers
 }
 
 async function getAccessToken ({

--- a/test/auth.js
+++ b/test/auth.js
@@ -27,6 +27,8 @@ async function getAccessTokenHeaders ({
     'x-stelace-env': t.context.env
   }
 
+  // optional versioning header per request
+  // specifying the API version allows to test compatibility with old functionalities
   if (apiVersion) {
     headers['x-stelace-version'] = apiVersion
   }

--- a/test/auth.js
+++ b/test/auth.js
@@ -27,8 +27,7 @@ async function getAccessTokenHeaders ({
     'x-stelace-env': t.context.env
   }
 
-  // optional versioning header per request
-  // specifying the API version allows to test compatibility with old functionalities
+  // allows to skip `x-stelace-version` header in individual requests
   if (apiVersion) {
     headers['x-stelace-version'] = apiVersion
   }

--- a/test/integration/api/assessment.spec.js
+++ b/test/integration/api/assessment.spec.js
@@ -5,7 +5,7 @@ const request = require('supertest')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata } = require('../../util')
+const { getObjectEvent, testEventMetadata, checkOffsetPaginatedListObject } = require('../../util')
 
 test.before(async t => {
   await before({ name: 'assessment' })(t)
@@ -43,19 +43,12 @@ const createAssessment = async (t) => {
 test('list assessments', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['assessment:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/assessments?assetId=ast_2l7fQps1I3a1gJYz2I3a')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  checkOffsetPaginatedListObject(t, obj)
 })
 
 test('finds an assessment', async (t) => {

--- a/test/integration/api/assessment.spec.js
+++ b/test/integration/api/assessment.spec.js
@@ -5,7 +5,12 @@ const request = require('supertest')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata, checkOffsetPaginatedListObject } = require('../../util')
+const {
+  getObjectEvent,
+  testEventMetadata,
+  checkOffsetPaginatedListObject,
+  checkCursorPaginatedListObject,
+} = require('../../util')
 
 test.before(async t => {
   await before({ name: 'assessment' })(t)
@@ -48,7 +53,7 @@ test('list assessments', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedListObject(t, obj)
+  checkCursorPaginatedListObject(t, obj)
 })
 
 test('finds an assessment', async (t) => {
@@ -984,4 +989,23 @@ test.serial('generates assessment__* events', async (t) => {
     objectId: assessmentToDelete.id
   })
   await testEventMetadata({ event: assessmentDeletedEvent, object: assessmentToDelete, t })
+})
+
+// //////// //
+// VERSIONS //
+// //////// //
+
+test('2019-05-20: list assessments', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['assessment:list:all']
+  })
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get('/assessments?assetId=ast_2l7fQps1I3a1gJYz2I3a')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedListObject(t, obj)
 })

--- a/test/integration/api/asset.spec.js
+++ b/test/integration/api/asset.spec.js
@@ -11,6 +11,7 @@ const {
   testEventMetadata,
   testEventDelay,
   checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject,
 } = require('../../util')
 
 test.before(async t => {
@@ -73,19 +74,13 @@ test('list assets for the current user', async (t) => {
 test('list assets with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['asset:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/assets?id=ast_0TYM7rs1OwP1gQRuCOwP')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
 })
 
 test('list assets with advanced filters', async (t) => {

--- a/test/integration/api/asset.spec.js
+++ b/test/integration/api/asset.spec.js
@@ -10,6 +10,10 @@ const {
   getObjectEvent,
   testEventMetadata,
   testEventDelay,
+
+  checkCursorPaginationScenario,
+  checkCursorPaginatedListObject,
+
   checkOffsetPaginationScenario,
   checkOffsetPaginatedListObject,
 } = require('../../util')
@@ -28,7 +32,7 @@ const defaultAssetTypeId = 'typ_RFpfQps1I3a1gJYz2I3a'
 test.serial('list assets with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['asset:list:all'] })
 
-  await checkOffsetPaginationScenario({
+  await checkCursorPaginationScenario({
     t,
     endpointUrl: '/assets',
     authorizationHeaders,
@@ -79,8 +83,8 @@ test('list assets with id filter', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedListObject(t, obj)
-  t.is(obj.nbResults, 1)
+  checkCursorPaginatedListObject(t, obj)
+  t.is(obj.results.length, 1)
 })
 
 test('list assets with advanced filters', async (t) => {
@@ -93,7 +97,6 @@ test('list assets with advanced filters', async (t) => {
 
   const obj1 = result1.body
 
-  t.is(obj1.results.length, obj1.nbResults)
   obj1.results.forEach(asset => {
     t.true(['usr_QVQfQps1I3a1gJYz2I3a', 'user-external-id'].includes(asset.ownerId))
     t.true(asset.active)
@@ -106,7 +109,6 @@ test('list assets with advanced filters', async (t) => {
 
   const obj2 = result2.body
 
-  t.is(obj2.results.length, obj2.nbResults)
   obj2.results.forEach(asset => {
     t.true(['usr_QVQfQps1I3a1gJYz2I3a', 'user-external-id'].includes(asset.ownerId))
   })
@@ -118,7 +120,6 @@ test('list assets with advanced filters', async (t) => {
 
   const obj3 = result3.body
 
-  t.is(obj3.results.length, obj3.nbResults)
   obj3.results.forEach(asset => {
     t.true(['typ_RFpfQps1I3a1gJYz2I3a'].includes(asset.assetTypeId))
     t.false(asset.validated)
@@ -131,7 +132,6 @@ test('list assets with advanced filters', async (t) => {
 
   const obj4 = result4.body
 
-  t.is(obj4.results.length, obj4.nbResults)
   obj4.results.forEach(asset => {
     t.true(asset.price >= 100)
     t.is(asset.categoryId, 'ctgy_ejQQps1I3a1gJYz2I3a')
@@ -960,4 +960,39 @@ test.serial('generates asset__* events', async (t) => {
   t.is(assetUpdatedEvent.object.name, assetUpdated.name)
   t.is(assetUpdatedEvent.object.metadata._custom.hasDataInNamespace, true)
   t.is(assetUpdatedEvent.object.metadata._custom.hasAdditionalDataInNamespace, true)
+})
+
+// //////// //
+// VERSIONS //
+// //////// //
+
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('2019-05-20: list assets with pagination', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['asset:list:all']
+  })
+
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/assets',
+    authorizationHeaders,
+  })
+})
+
+test('2019-05-20: list assets with id filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['asset:list:all']
+  })
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get('/assets?id=ast_0TYM7rs1OwP1gQRuCOwP')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedListObject(t, obj)
+  t.is(obj.nbResults, 1)
 })

--- a/test/integration/api/asset.spec.js
+++ b/test/integration/api/asset.spec.js
@@ -9,7 +9,8 @@ const { getModels } = require('../../../src/models')
 const {
   getObjectEvent,
   testEventMetadata,
-  testEventDelay
+  testEventDelay,
+  checkOffsetPaginationScenario,
 } = require('../../util')
 
 test.before(async t => {
@@ -22,22 +23,15 @@ test.after(after())
 // from fixtures
 const defaultAssetTypeId = 'typ_RFpfQps1I3a1gJYz2I3a'
 
-test('list assets', async (t) => {
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('list assets with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['asset:list:all'] })
 
-  const result = await request(t.context.serverUrl)
-    .get('/assets?page=2')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/assets',
+    authorizationHeaders,
+  })
 })
 
 test('list assets for the current user', async (t) => {

--- a/test/integration/api/availability.spec.js
+++ b/test/integration/api/availability.spec.js
@@ -9,7 +9,8 @@ const {
   computeDate,
   getObjectEvent,
   testEventMetadata,
-  checkOffsetPaginationScenario
+  checkOffsetPaginationScenario,
+  checkCursorPaginationScenario,
 } = require('../../util')
 
 test.before(async t => {
@@ -44,7 +45,7 @@ test('get availabilities graph', async (t) => {
 test.serial('list availabilities with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['availability:list:all'] })
 
-  await checkOffsetPaginationScenario({
+  await checkCursorPaginationScenario({
     t,
     endpointUrl: '/availabilities?assetId=ast_0TYM7rs1OwP1gQRuCOwP',
     authorizationHeaders,
@@ -733,5 +734,24 @@ test.serial('generates availability__* events', async (t) => {
     event: availabilityDeletedEvent,
     object: availabilityUpdated,
     t
+  })
+})
+
+// //////// //
+// VERSIONS //
+// //////// //
+
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('2019-05-20: list availabilities with pagination', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['availability:list:all']
+  })
+
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/availabilities?assetId=ast_0TYM7rs1OwP1gQRuCOwP',
+    authorizationHeaders,
   })
 })

--- a/test/integration/api/availability.spec.js
+++ b/test/integration/api/availability.spec.js
@@ -8,7 +8,8 @@ const { getAccessTokenHeaders } = require('../../auth')
 const {
   computeDate,
   getObjectEvent,
-  testEventMetadata
+  testEventMetadata,
+  checkOffsetPaginationScenario
 } = require('../../util')
 
 test.before(async t => {
@@ -39,22 +40,15 @@ test('get availabilities graph', async (t) => {
   })
 })
 
-test('list availabilities', async (t) => {
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('list availabilities with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['availability:list:all'] })
 
-  const result = await request(t.context.serverUrl)
-    .get('/availabilities?assetId=ast_0TYM7rs1OwP1gQRuCOwP&page=2')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/availabilities?assetId=ast_0TYM7rs1OwP1gQRuCOwP',
+    authorizationHeaders,
+  })
 })
 
 test('creates an availability with a fixed quantity', async (t) => {

--- a/test/integration/api/customAttribute.spec.js
+++ b/test/integration/api/customAttribute.spec.js
@@ -6,7 +6,12 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata, checkOffsetPaginationScenario } = require('../../util')
+const {
+  getObjectEvent,
+  testEventMetadata,
+  checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject
+} = require('../../util')
 
 test.before(async (t) => {
   await before({ name: 'customAttribute' })(t)
@@ -29,19 +34,13 @@ test.serial('list custom attributes with pagination', async (t) => {
 test('list custom attributes with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['customAttribute:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/custom-attributes?id=attr_WmwQps1I3a1gJYz2I3a')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
 })
 
 test('finds a custom attribute', async (t) => {

--- a/test/integration/api/customAttribute.spec.js
+++ b/test/integration/api/customAttribute.spec.js
@@ -6,7 +6,7 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata } = require('../../util')
+const { getObjectEvent, testEventMetadata, checkOffsetPaginationScenario } = require('../../util')
 
 test.before(async (t) => {
   await before({ name: 'customAttribute' })(t)
@@ -15,22 +15,15 @@ test.before(async (t) => {
 // test.beforeEach(beforeEach())
 test.after(after())
 
-test('list custom attributes', async (t) => {
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('list custom attributes with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['customAttribute:list:all'] })
 
-  const result = await request(t.context.serverUrl)
-    .get('/custom-attributes')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/custom-attributes',
+    authorizationHeaders,
+  })
 })
 
 test('list custom attributes with id filter', async (t) => {

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -6,7 +6,11 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { checkStatsObject, checkOffsetPaginationScenario } = require('../../util')
+const {
+  checkOffsetPaginatedStatsObject,
+  checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject,
+} = require('../../util')
 
 test.before(async (t) => {
   await before({ name: 'document' })(t)
@@ -49,7 +53,7 @@ test('get simple documents stats', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -82,7 +86,7 @@ test('get aggregated field stats', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -122,7 +126,7 @@ test('get aggregated field stats by authorId and filter on an authorId', async (
     .set(authorizationHeaders)
     .expect(200)
 
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -163,7 +167,7 @@ test('get aggregated field stats with ranking', async (t) => {
     .expect(200)
 
   let ranking
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -213,7 +217,7 @@ test('get aggregated field stats with ranking with specified label', async (t) =
     .expect(200)
 
   let ranking
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -329,7 +333,7 @@ test('get aggregated field stats with ranking and postranking filter', async (t)
     .set(authorizationHeaders)
     .expect(200)
 
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -372,14 +376,7 @@ test('get aggregated field stats with ranking and preranking filter', async (t) 
     .set(authorizationHeaders)
     .expect(200)
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-
-  checkStatsObject({
+  checkOffsetPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -407,13 +404,8 @@ test('get aggregated field stats with multiple labels', async (t) => {
 
   const obj = result.body
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.is(obj.nbResults, 1)
-  t.true(Array.isArray(obj.results))
+  checkOffsetPaginatedListObject(t, obj)
+  t.is(obj.results.length, 1)
 
   const checkStatObject = obj => {
     t.is(typeof obj, 'object')
@@ -534,19 +526,13 @@ test.serial('list documents with pagination', async (t) => {
 test('list documents with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/documents?type=invoice&id=doc_WWRfQps1I3a1gJYz2I3a')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
 })
 
 test('list documents with advanced filters', async (t) => {

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -10,6 +10,10 @@ const {
   checkOffsetPaginatedStatsObject,
   checkOffsetPaginationScenario,
   checkOffsetPaginatedListObject,
+
+  checkCursorPaginatedStatsObject,
+  checkCursorPaginationScenario,
+  checkCursorPaginatedListObject,
 } = require('../../util')
 
 test.before(async (t) => {
@@ -23,7 +27,7 @@ test.after(after())
 test.serial('get simple documents stats with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:stats:all'] })
 
-  await checkOffsetPaginationScenario({
+  await checkCursorPaginationScenario({
     t,
     endpointUrl: '/documents/stats?type=movie&groupBy=data.director',
     authorizationHeaders,
@@ -53,7 +57,7 @@ test('get simple documents stats', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -86,7 +90,7 @@ test('get aggregated field stats', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -126,7 +130,7 @@ test('get aggregated field stats by authorId and filter on an authorId', async (
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -167,7 +171,7 @@ test('get aggregated field stats with ranking', async (t) => {
     .expect(200)
 
   let ranking
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -179,7 +183,7 @@ test('get aggregated field stats with ranking', async (t) => {
       t.is(typeof result.ranking, 'number')
       t.is(typeof result.lowestRanking, 'number')
 
-      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+      t.is(result.lowestRanking, obj.results.length) // is true because there is no filter
 
       // check ranking order
       if (typeof ranking === 'undefined') {
@@ -217,7 +221,7 @@ test('get aggregated field stats with ranking with specified label', async (t) =
     .expect(200)
 
   let ranking
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -229,7 +233,7 @@ test('get aggregated field stats with ranking with specified label', async (t) =
       t.is(typeof result.ranking, 'number')
       t.is(typeof result.lowestRanking, 'number')
 
-      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+      t.is(result.lowestRanking, obj.results.length) // is true because there is no filter
 
       // check ranking order
       if (typeof ranking === 'undefined') {
@@ -311,7 +315,7 @@ test('get aggregated field stats with ranking and postranking filter', async (t)
     .set(authorizationHeaders)
     .expect(200)
 
-  const lowestRanking = beforeObj.nbResults
+  const lowestRanking = beforeObj.results.length
 
   const directorRanking = beforeObj.results.reduce((memo, result) => {
     if (result.groupByValue === 'Hayao Miyazaki') {
@@ -333,7 +337,7 @@ test('get aggregated field stats with ranking and postranking filter', async (t)
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -376,7 +380,7 @@ test('get aggregated field stats with ranking and preranking filter', async (t) 
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedStatsObject({
+  checkCursorPaginatedStatsObject({
     t,
     obj,
     groupBy,
@@ -404,7 +408,9 @@ test('get aggregated field stats with multiple labels', async (t) => {
 
   const obj = result.body
 
-  checkOffsetPaginatedListObject(t, obj)
+  // do not check cursor because when wildcard labels are passed, an aggregated result is returned
+  // so cursors cannot be provided
+  checkCursorPaginatedListObject(t, obj, { cursorCheck: false })
   t.is(obj.results.length, 1)
 
   const checkStatObject = obj => {
@@ -516,7 +522,7 @@ test('fails to get aggregated stats with non-number field', async (t) => {
 test.serial('list documents with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:list:all'] })
 
-  await checkOffsetPaginationScenario({
+  await checkCursorPaginationScenario({
     t,
     endpointUrl: '/documents?type=invoice',
     authorizationHeaders,
@@ -531,8 +537,8 @@ test('list documents with id filter', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  checkOffsetPaginatedListObject(t, obj)
-  t.is(obj.nbResults, 1)
+  checkCursorPaginatedListObject(t, obj)
+  t.is(obj.results.length, 1)
 })
 
 test('list documents with advanced filters', async (t) => {
@@ -545,7 +551,6 @@ test('list documents with advanced filters', async (t) => {
 
   const obj1 = result1.body
 
-  t.is(obj1.results.length, obj1.nbResults)
   obj1.results.forEach(doc => {
     t.true(['doc_WWRfQps1I3a1gJYz2I3a', 'user-external-id'].includes(doc.authorId))
   })
@@ -557,7 +562,6 @@ test('list documents with advanced filters', async (t) => {
 
   const obj2 = result2.body
 
-  t.is(obj2.results.length, obj2.nbResults)
   obj2.results.forEach(doc => {
     t.true(['https://example.com/invoice'].includes(doc.data.invoiceUrl))
   })
@@ -670,7 +674,7 @@ test('list documents with label filter', async (t) => {
 
   const obj3 = result3.body
 
-  t.true(obj3.nbResults > 0)
+  t.true(obj3.results.length > 0)
   obj3.results.forEach(result => {
     t.is(result.label, 'main:popular')
   })
@@ -682,7 +686,7 @@ test('list documents with label filter', async (t) => {
 
   const obj4 = result4.body
 
-  t.true(obj4.nbResults > 0)
+  t.true(obj4.results.length > 0)
   obj4.results.forEach(result => {
     t.true(['main:popular', 'main:random'].includes(result.label))
   })
@@ -694,7 +698,7 @@ test('list documents with label filter', async (t) => {
 
   const obj5 = result5.body
 
-  t.true(obj5.nbResults > 0)
+  t.true(obj5.results.length > 0)
   obj5.results.forEach(result => {
     t.true(result.label.startsWith('main:'))
   })
@@ -962,4 +966,388 @@ test('fails to update a document if missing or invalid parameters', async (t) =>
   t.true(error.message.includes('"metadata" must be of type object'))
   t.true(error.message.includes('"platformData" must be of type object'))
   t.true(error.message.includes('"replaceDataProperties" must be an array'))
+})
+
+// //////// //
+// VERSIONS //
+// //////// //
+
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('2019-05-20: get simple documents stats with pagination', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['document:stats:all']
+  })
+
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/documents/stats?type=movie&groupBy=data.director',
+    authorizationHeaders,
+    orderBy: 'count'
+  })
+})
+
+test('2019-05-20: get simple documents stats', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'data.director'
+  const filters = 'type=movie'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    results: documents
+  })
+})
+
+test('2019-05-20: get aggregated field stats', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'undefined')
+      t.is(typeof result.lowestRanking, 'undefined')
+    }
+  })
+})
+
+test('2019-05-20: get aggregated field stats by authorId and filter on an authorId', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'authorId'
+  const field = 'data.score'
+  const filters = 'type=movie&authorId=user-external-id'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'undefined')
+      t.is(typeof result.lowestRanking, 'undefined')
+    }
+  })
+})
+
+test('2019-05-20: get aggregated field stats with ranking', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie&authorId=user-external-id'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  let ranking
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
+
+      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+
+      // check ranking order
+      if (typeof ranking === 'undefined') {
+        ranking = result.ranking
+      } else {
+        t.true(ranking < result.ranking)
+      }
+    }
+  })
+})
+
+test('2019-05-20: get aggregated field stats with ranking with specified label', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie&label=source:imdb'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  let ranking
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
+
+      t.is(result.lowestRanking, obj.nbResults) // is true because there is no filter
+
+      // check ranking order
+      if (typeof ranking === 'undefined') {
+        ranking = result.ranking
+      } else {
+        t.true(ranking < result.ranking)
+      }
+    }
+  })
+
+  const filters2 = 'type=movie&label=source:random'
+
+  const { body: obj2 } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters2}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  t.true(obj.results[0].avg !== obj2.results[0].avg)
+})
+
+test('2019-05-20: get aggregated field stats with ranking and postranking filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: beforeObj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const lowestRanking = beforeObj.nbResults
+
+  const directorRanking = beforeObj.results.reduce((memo, result) => {
+    if (result.groupByValue === 'Hayao Miyazaki') {
+      return result.ranking
+    }
+    return memo
+  }, null)
+
+  // Now only filter on the director, ranking stats should not changed
+  const filters2 = 'type=movie&data[director]=Hayao+Miyazaki'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters2}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters2}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
+
+      t.is(result.ranking, directorRanking)
+      t.is(result.lowestRanking, lowestRanking)
+    }
+  })
+})
+
+test('2019-05-20: get aggregated field stats with ranking and preranking filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all'
+    ]
+  })
+
+  const groupBy = 'data.director'
+  const field = 'data.score'
+  const filters = 'type=movie&data[composer]=Masaru+Sato'
+  const orderBy = 'avg'
+  const order = 'asc'
+
+  const { body: { results: documents } } = await request(t.context.serverUrl)
+    .get(`/documents?${filters}`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get(`/documents/stats?groupBy=${groupBy}&field=${field}&orderBy=${orderBy}&order=${order}&${filters}&computeRanking=true`)
+    .set(authorizationHeaders)
+    .expect(200)
+
+  t.true(typeof obj === 'object')
+  t.true(typeof obj.nbResults === 'number')
+  t.true(typeof obj.nbPages === 'number')
+  t.true(typeof obj.page === 'number')
+  t.true(typeof obj.nbResultsPerPage === 'number')
+  t.true(Array.isArray(obj.results))
+
+  checkOffsetPaginatedStatsObject({
+    t,
+    obj,
+    groupBy,
+    field,
+    results: documents,
+    orderBy,
+    order,
+    additionalResultCheckFn: (result) => {
+      t.is(typeof result.ranking, 'number')
+      t.is(typeof result.lowestRanking, 'number')
+    }
+  })
+})
+
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('2019-05-20: list documents with pagination', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['document:list:all']
+  })
+
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/documents?type=invoice',
+    authorizationHeaders,
+  })
+})
+
+test('2019-05-20: list documents with id filter', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    apiVersion: '2019-05-20',
+    t,
+    permissions: ['document:list:all']
+  })
+
+  const { body: obj } = await request(t.context.serverUrl)
+    .get('/documents?type=invoice&id=doc_WWRfQps1I3a1gJYz2I3a')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  checkOffsetPaginatedListObject(t, obj)
+  t.is(obj.nbResults, 1)
 })

--- a/test/integration/api/entry.spec.js
+++ b/test/integration/api/entry.spec.js
@@ -5,7 +5,12 @@ const request = require('supertest')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata, checkOffsetPaginationScenario } = require('../../util')
+const {
+  getObjectEvent,
+  testEventMetadata,
+  checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject,
+} = require('../../util')
 
 test.before(async t => {
   await before({ name: 'entry' })(t)
@@ -33,12 +38,8 @@ test('list entries with id filter', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
 })
 
 test('list entries with advanced filters', async (t) => {

--- a/test/integration/api/message.spec.js
+++ b/test/integration/api/message.spec.js
@@ -5,7 +5,12 @@ const request = require('supertest')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata, checkOffsetPaginationScenario } = require('../../util')
+const {
+  getObjectEvent,
+  testEventMetadata,
+  checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject,
+} = require('../../util')
 
 test.before(async t => {
   await before({ name: 'message' })(t)
@@ -28,41 +33,28 @@ test.serial('list messages with pagination', async (t) => {
 test('list messages with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['message:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/messages?id=msg_Vuz9KRs10NK1gAHrp0NK')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
   t.is(obj.results[0].id, 'msg_Vuz9KRs10NK1gAHrp0NK')
 })
 
 test('list messages with advanced filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['message:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/messages?senderId=user-external-id')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
+  const checkResultsFn = (t, message) => t.is(message.senderId, 'user-external-id')
 
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj, { checkResultsFn })
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-
-  obj.results.forEach(result => {
-    t.is(result.senderId, 'user-external-id')
-  })
 })
 
 test('cannot list messages if the current user does not belong to the conversation', async (t) => {

--- a/test/integration/api/order.spec.js
+++ b/test/integration/api/order.spec.js
@@ -6,7 +6,7 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata } = require('../../util')
+const { getObjectEvent, testEventMetadata, checkOffsetPaginationScenario } = require('../../util')
 
 test.before(async (t) => {
   await before({ name: 'order' })(t)
@@ -137,22 +137,15 @@ test('previews an order with lines and moves', async (t) => {
   })
 })
 
-test('list orders', async (t) => {
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('list orders with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['order:list:all'] })
 
-  const result = await request(t.context.serverUrl)
-    .get('/orders?page=2')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/orders',
+    authorizationHeaders,
+  })
 })
 
 test('list orders with id filter', async (t) => {

--- a/test/integration/api/order.spec.js
+++ b/test/integration/api/order.spec.js
@@ -6,7 +6,12 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
-const { getObjectEvent, testEventMetadata, checkOffsetPaginationScenario } = require('../../util')
+const {
+  getObjectEvent,
+  testEventMetadata,
+  checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject
+} = require('../../util')
 
 test.before(async (t) => {
   await before({ name: 'order' })(t)
@@ -151,19 +156,13 @@ test.serial('list orders with pagination', async (t) => {
 test('list orders with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['order:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/orders?id=ord_eP0hwes1jwf1gxMLCjwf')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
 })
 
 test('list orders with advanced filters', async (t) => {

--- a/test/integration/api/task.spec.js
+++ b/test/integration/api/task.spec.js
@@ -7,7 +7,11 @@ const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders, getApiKey } = require('../../auth')
-const { computeDate, checkOffsetPaginationScenario } = require('../../util')
+const {
+  computeDate,
+  checkOffsetPaginationScenario,
+  checkOffsetPaginatedListObject,
+} = require('../../util')
 
 const { getRoundedDate } = require('../../../src/util/time')
 const { encodeBase64 } = require('../../../src/util/encoding')
@@ -40,7 +44,7 @@ test.serial('list tasks with pagination', async (t) => {
     t,
     endpointUrl: '/tasks',
     authorizationHeaders,
-    checkFn: (t, task) => {
+    checkResultsFn: (t, task) => {
       t.truthy(task.id)
       t.true(_.isString(task.eventType))
     }
@@ -50,19 +54,13 @@ test.serial('list tasks with pagination', async (t) => {
 test('list tasks with id filter', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['task:list:all'] })
 
-  const result = await request(t.context.serverUrl)
+  const { body: obj } = await request(t.context.serverUrl)
     .get('/tasks?id=task_4bJEZe1bA91i7IQYbA8')
     .set(authorizationHeaders)
     .expect(200)
 
-  const obj = result.body
-
-  t.is(typeof obj, 'object')
+  checkOffsetPaginatedListObject(t, obj)
   t.is(obj.nbResults, 1)
-  t.is(obj.nbPages, 1)
-  t.is(obj.page, 1)
-  t.is(typeof obj.nbResultsPerPage, 'number')
-  t.is(obj.results.length, 1)
 })
 
 test('list tasks with advanced filters', async (t) => {

--- a/test/integration/api/transaction.spec.js
+++ b/test/integration/api/transaction.spec.js
@@ -8,7 +8,7 @@ const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
 
 const { getModels } = require('../../../src/models')
-const { computeDate } = require('../../util')
+const { computeDate, checkOffsetPaginationScenario } = require('../../util')
 const { getObjectEvent, testEventMetadata } = require('../../util')
 
 test.before(async t => {
@@ -60,22 +60,15 @@ const createTransactionWithAsset = async (t) => {
   return transaction
 }
 
-test('list transactions', async (t) => {
+// need serial to ensure there is no insertion/deletion during pagination scenario
+test.serial('list transactions with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['transaction:list:all'] })
 
-  const result = await request(t.context.serverUrl)
-    .get('/transactions')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj = result.body
-
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
+  await checkOffsetPaginationScenario({
+    t,
+    endpointUrl: '/transactions',
+    authorizationHeaders,
+  })
 })
 
 test('list transactions for the current user', async (t) => {

--- a/test/unit/util/math.spec.js
+++ b/test/unit/util/math.spec.js
@@ -3,8 +3,16 @@ require('dotenv').config()
 const test = require('ava')
 
 const {
+  sumDecimals,
   roundDecimal
 } = require('../../../src/util/math')
+
+test('sum numbers', (t) => {
+  t.is(sumDecimals([8.1, 8.2]), 16.3) // 16.299999999999997 in JS
+
+  t.is(sumDecimals([8.3, 8.7, 8, 8.1]), 33.1) // 33.1 in JS
+  t.is(sumDecimals([8, 8.7, 8.1, 8.3]), 33.1) // 33.099999999999994 in JS
+})
 
 test('rounds number with precision', (t) => {
   t.is(roundDecimal(8.325, 2), 8.33)

--- a/test/util.js
+++ b/test/util.js
@@ -154,15 +154,15 @@ async function checkCursorPaginationScenario ({
   const orders = ['desc', 'asc']
 
   for (const order of orders) {
-    let orderValue
+    let previousValue
     const checkOrder = (results) => {
       results.forEach(r => {
-        if (!_.isUndefined(orderValue)) {
-          if (order === 'desc') t.true(r[orderBy] <= orderValue)
-          else t.true(r[orderBy] >= orderValue)
+        if (!_.isUndefined(previousValue)) {
+          if (order === 'desc') t.true(r[orderBy] <= previousValue)
+          else t.true(r[orderBy] >= previousValue)
         }
 
-        orderValue = r[orderBy]
+        previousValue = r[orderBy]
       })
     }
 
@@ -209,6 +209,7 @@ async function checkCursorPaginationScenario ({
 
     isPaginationObject(page2Obj)
     checkOrder(page2Obj.results)
+    t.is(_.intersectionWith(page1Obj.results, page2Obj.results, _.isEqual).length, 0)
 
     t.true(page2Obj.hasPreviousPage)
 
@@ -259,15 +260,15 @@ async function checkOffsetPaginationScenario ({
   const orders = ['desc', 'asc']
 
   for (const order of orders) {
-    let orderValue
+    let previousValue
     const checkOrder = (results) => {
       results.forEach(r => {
-        if (!_.isUndefined(orderValue)) {
-          if (order === 'desc') t.true(r[orderBy] <= orderValue)
-          else t.true(r[orderBy] >= orderValue)
+        if (!_.isUndefined(previousValue)) {
+          if (order === 'desc') t.true(r[orderBy] <= previousValue)
+          else t.true(r[orderBy] >= previousValue)
         }
 
-        orderValue = r[orderBy]
+        previousValue = r[orderBy]
       })
     }
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,6 +1,6 @@
 const { computeDate, isDateString, truncateDate } = require('../src/util/time')
 const { getModels } = require('../src/models')
-const { roundDecimal } = require('../src/util/math')
+const { roundDecimal, sumDecimals } = require('../src/util/math')
 const WebhookManager = require('./webhook-manager')
 const _ = require('lodash')
 const request = require('supertest')
@@ -261,8 +261,8 @@ function checkOffsetPaginatedStatsObject ({
 
     const nullIfNone = (count, nb) => count === 0 ? null : nb
 
-    const avg = nullIfNone(count, results.reduce((nb, r) => nb + _.get(r, field), 0) / results.length)
-    const sum = nullIfNone(count, results.reduce((nb, r) => nb + _.get(r, field), 0))
+    const sum = nullIfNone(count, sumDecimals(_.compact(results.map(r => _.get(r, field)))))
+    const avg = nullIfNone(count, sum / results.length)
     const min = nullIfNone(count, results.reduce((nb, r) => Math.min(_.get(r, field), nb), _.get(results[0], field)))
     const max = nullIfNone(count, results.reduce((nb, r) => Math.max(_.get(r, field), nb), _.get(results[0], field)))
 

--- a/test/util.js
+++ b/test/util.js
@@ -24,8 +24,8 @@ module.exports = {
 
   checkOffsetPaginationScenario,
   checkOffsetPaginatedListObject,
-  checkStatsObject,
-  checkHistoryObject,
+  checkOffsetPaginatedStatsObject,
+  checkOffsetPaginatedHistoryObject,
 }
 
 /**
@@ -236,7 +236,7 @@ async function checkOffsetPaginationScenario ({
  * @param {Function} [additionalResultCheckFn] - if defined, will perform additional check
  *     on each item of results array
  */
-function checkStatsObject ({
+function checkOffsetPaginatedStatsObject ({
   t,
   obj,
   groupBy,
@@ -252,13 +252,7 @@ function checkStatsObject ({
   results = results.filter(e => !_.isUndefined(_.get(e, groupBy)))
   const resultsByType = _.groupBy(results, groupBy)
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-  t.is(obj.nbResults, obj.results.length)
+  checkOffsetPaginatedListObject(t, obj)
 
   obj.results.forEach(result => {
     const key = expandedGroupByField ? result.groupByValue : result[groupBy]
@@ -330,7 +324,7 @@ function checkStatsObject ({
  * @param {String}   [order = 'desc']
  * @param {Function} [additionalResultCheckFn] - if defined, will perform additional check on `result`
  */
-function checkHistoryObject ({
+function checkOffsetPaginatedHistoryObject ({
   t,
   obj,
   groupBy,
@@ -350,13 +344,7 @@ function checkHistoryObject ({
     else if (groupBy === 'month') return date
   })
 
-  t.true(typeof obj === 'object')
-  t.true(typeof obj.nbResults === 'number')
-  t.true(typeof obj.nbPages === 'number')
-  t.true(typeof obj.page === 'number')
-  t.true(typeof obj.nbResultsPerPage === 'number')
-  t.true(Array.isArray(obj.results))
-  t.is(obj.nbResults, obj.results.length)
+  checkOffsetPaginatedListObject(t, obj)
 
   obj.results.forEach(result => {
     const key = result[groupBy]

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,6 +922,11 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"


### PR DESCRIPTION
Offset pagination isn't scalable for two reasons:
- retrieving count (full scan without caching strategy)
- offsetting results (scan first pages to reach wanted page)

Cursor pagination solves that issue by using cursors to directly
point to the location of the previous results limits.

Internally, this is transformed into basic comparisons,
which is really fast with indexes.

The drawback is that count isn't available anymore
and there is no way to directly jump into a specific page.

BREAKING CHANGE:
For version 2019-05-20, the offset pagination is served.
The cursor pagination is served for higher versions.

New platforms will directly use the new pagination.
But existing platforms will preserve the old pagination.

A manual system config update on `stelace.stelaceVersion`
to set a higher version is needed to use the new pagination globally.

Otherwise you can provide the header 'x-stelace-version'
at each request to check if everything works fine before migrating
globally.