### PR TITLE
feat: paginate remaining non-paginated list endpoints

### DIFF
--- a/src/routes/assetType.js
+++ b/src/routes/assetType.js
@@ -18,12 +18,31 @@ function init (server, { middlewares, helpers } = {}) {
   }, cache(), checkPermissions([
     'assetType:list:all'
   ]), wrapAction(async (req, res) => {
-    const params = populateRequesterParams(req)({
+    const fields = [
+      'orderBy',
+      'order',
+      'nbResultsPerPage',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
+
+      'id',
+      'createdDate',
+      'updatedDate',
+      'isDefault',
+      'active',
+    ]
+
+    const payload = _.pick(req.query, fields)
+
+    let params = populateRequesterParams(req)({
       type: 'list'
     })
 
-    const result = await requester.send(params)
-    return result
+    params = Object.assign({}, params, payload)
+
+    return requester.send(params)
   }))
 
   server.get({

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 let requester
 
 function init (server, { middlewares, helpers } = {}) {
@@ -16,12 +18,30 @@ function init (server, { middlewares, helpers } = {}) {
   }, checkPermissions([
     'category:list:all'
   ]), cache(), wrapAction(async (req, res) => {
-    const params = populateRequesterParams(req)({
+    const fields = [
+      'orderBy',
+      'order',
+      'nbResultsPerPage',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
+
+      'id',
+      'createdDate',
+      'updatedDate',
+      'parentId',
+    ]
+
+    const payload = _.pick(req.query, fields)
+
+    let params = populateRequesterParams(req)({
       type: 'list'
     })
 
-    const result = await requester.send(params)
-    return result
+    params = Object.assign({}, params, payload)
+
+    return requester.send(params)
   }))
 
   server.get({

--- a/src/routes/role.js
+++ b/src/routes/role.js
@@ -17,12 +17,29 @@ function init (server, { middlewares, helpers } = {}) {
   }, checkPermissions([
     'role:list:all'
   ]), wrapAction(async (req, res) => {
-    const params = populateRequesterParams(req)({
+    const fields = [
+      'orderBy',
+      'order',
+      'nbResultsPerPage',
+
+      // cursor pagination
+      'startingAfter',
+      'endingBefore',
+
+      'id',
+      'createdDate',
+      'updatedDate',
+    ]
+
+    const payload = _.pick(req.query, fields)
+
+    let params = populateRequesterParams(req)({
       type: 'list'
     })
 
-    const result = await requester.send(params)
-    return result
+    params = Object.assign({}, params, payload)
+
+    return requester.send(params)
   }))
 
   server.get({

--- a/src/versions/request/assetType.js
+++ b/src/versions/request/assetType.js
@@ -1,0 +1,21 @@
+const requestChanges = {
+  '2019-05-20': [
+    {
+      target: 'assetType.list',
+      description: 'Asset types list is returned without pagination meta',
+      up: async (params) => {
+        const { req } = params
+
+        req.query = {
+          orderBy: 'createdDate',
+          order: 'desc',
+          nbResultsPerPage: 10000, // high number to retrieve all workflows in theory
+        }
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = requestChanges

--- a/src/versions/request/category.js
+++ b/src/versions/request/category.js
@@ -1,0 +1,21 @@
+const requestChanges = {
+  '2019-05-20': [
+    {
+      target: 'category.list',
+      description: 'Categories list is returned without pagination meta',
+      up: async (params) => {
+        const { req } = params
+
+        req.query = {
+          orderBy: 'createdDate',
+          order: 'desc',
+          nbResultsPerPage: 10000, // high number to retrieve all workflows in theory
+        }
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = requestChanges

--- a/src/versions/request/index.js
+++ b/src/versions/request/index.js
@@ -4,6 +4,9 @@ const { apiVersions, transformConfigsIntoChanges } = require('../util')
 const listRequestChangeConfigs = [
   require('./beforeAll'),
 
+  require('./assetType'),
+  require('./category'),
+  require('./role'),
   require('./webhook'),
   require('./workflow'),
 ]

--- a/src/versions/request/role.js
+++ b/src/versions/request/role.js
@@ -1,0 +1,21 @@
+const requestChanges = {
+  '2019-05-20': [
+    {
+      target: 'role.list',
+      description: 'Roles list is returned without pagination meta',
+      up: async (params) => {
+        const { req } = params
+
+        req.query = {
+          orderBy: 'createdDate',
+          order: 'desc',
+          nbResultsPerPage: 10000, // high number to retrieve all workflows in theory
+        }
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = requestChanges

--- a/src/versions/response/assetType.js
+++ b/src/versions/response/assetType.js
@@ -1,0 +1,16 @@
+const responseChanges = {
+  '2020-08-10': [
+    {
+      target: 'assetType.list',
+      description: 'Asset types list is returned without pagination meta',
+      down: async (params) => {
+        const paginationMeta = params.result
+        params.result = paginationMeta.results
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = responseChanges

--- a/src/versions/response/category.js
+++ b/src/versions/response/category.js
@@ -1,0 +1,16 @@
+const responseChanges = {
+  '2020-08-10': [
+    {
+      target: 'category.list',
+      description: 'Categories list is returned without pagination meta',
+      down: async (params) => {
+        const paginationMeta = params.result
+        params.result = paginationMeta.results
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = responseChanges

--- a/src/versions/response/index.js
+++ b/src/versions/response/index.js
@@ -3,6 +3,9 @@ const VersionTransformer = require('../transformer')
 const { transformConfigsIntoChanges } = require('../util')
 
 const listResponseChangeConfigs = [
+  require('./assetType'),
+  require('./category'),
+  require('./role'),
   require('./webhook'),
   require('./workflow'),
 ]

--- a/src/versions/response/role.js
+++ b/src/versions/response/role.js
@@ -1,0 +1,16 @@
+const responseChanges = {
+  '2020-08-10': [
+    {
+      target: 'role.list',
+      description: 'Roles list is returned without pagination meta',
+      down: async (params) => {
+        const paginationMeta = params.result
+        params.result = paginationMeta.results
+
+        return params
+      }
+    }
+  ],
+}
+
+module.exports = responseChanges

--- a/src/versions/validation/category.js
+++ b/src/versions/validation/category.js
@@ -1,6 +1,37 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
+
+const orderByFields = [
+  'createdDate',
+  'updatedDate',
+]
 
 const schemas = {}
+
+// ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = {
+  query: Joi.object()
+    .keys({
+      // order
+      orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+      order: Joi.string().valid('asc', 'desc').default('desc'),
+
+      // cursor pagination
+      nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+
+      // filters
+      id: Joi.array().unique().items(Joi.string()).single(),
+      createdDate: getRangeFilter(Joi.string().isoDate()),
+      updatedDate: getRangeFilter(Joi.string().isoDate()),
+      parentId: Joi.array().unique().items(Joi.string()).single(),
+    })
+    .oxor('startingAfter', 'endingBefore')
+}
 
 // ////////// //
 // 2019-05-20 //
@@ -28,6 +59,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'category.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'category.list',

--- a/src/versions/validation/role.js
+++ b/src/versions/validation/role.js
@@ -1,6 +1,36 @@
-const { Joi, objectIdParamsSchema } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
+
+const orderByFields = [
+  'createdDate',
+  'updatedDate',
+]
 
 const schemas = {}
+
+// ////////// //
+// 2020-08-10 //
+// ////////// //
+schemas['2020-08-10'] = {}
+schemas['2020-08-10'].list = {
+  query: Joi.object()
+    .keys({
+      // order
+      orderBy: Joi.string().valid(...orderByFields).default('createdDate'),
+      order: Joi.string().valid('asc', 'desc').default('desc'),
+
+      // cursor pagination
+      nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
+      startingAfter: Joi.string(),
+      endingBefore: Joi.string(),
+
+      // filters
+      id: Joi.array().unique().items(Joi.string()).single(),
+      createdDate: getRangeFilter(Joi.string().isoDate()),
+      updatedDate: getRangeFilter(Joi.string().isoDate()),
+    })
+    .oxor('startingAfter', 'endingBefore')
+}
 
 // ////////// //
 // 2019-05-20 //
@@ -33,6 +63,13 @@ schemas['2019-05-20'].remove = {
 }
 
 const validationVersions = {
+  '2020-08-10': [
+    {
+      target: 'role.list',
+      schema: schemas['2020-08-10'].list
+    },
+  ],
+
   '2019-05-20': [
     {
       target: 'role.list',

--- a/test/integration/api/asset.spec.js
+++ b/test/integration/api/asset.spec.js
@@ -270,7 +270,7 @@ test.serial('creating an asset if there is no asset type will create one', async
     ]
   })
 
-  const { body: assetTypes } = await request(t.context.serverUrl)
+  const { body: { results: assetTypes } } = await request(t.context.serverUrl)
     .get('/asset-types')
     .set(authorizationHeaders)
     .expect(200)


### PR DESCRIPTION
Some list endpoints weren’t paginated yet:
- asset types
- categories
- roles

Those endpoints will benefit from the cursor pagination.