### PR TITLE
feat!: range filter forbids redundant relational operators

### DIFF
--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -98,7 +98,7 @@ const objectIdParamsSchema = customJoi.object().keys({
   id: customJoi.string().required()
 }).required()
 
-function getRangeFilter (joiType, forbidSameBoundaryType = false) {
+function getRangeFilter (joiType) {
   const rangeSchema = customJoi.object().pattern(
     customJoi.string().valid('lt', 'lte', 'gt', 'gte'),
     joiType
@@ -106,11 +106,9 @@ function getRangeFilter (joiType, forbidSameBoundaryType = false) {
 
   return customJoi.alternatives().try(
     joiType,
-    forbidSameBoundaryType
-      ? rangeSchema
-        .oxor('lt', 'lte')
-        .oxor('gt', 'gte')
-      : rangeSchema
+    rangeSchema
+      .oxor('lt', 'lte')
+      .oxor('gt', 'gte')
   )
 }
 

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -62,7 +62,7 @@ schemas['2020-08-10'].getHistory = {
 
     // filters
     id: Joi.array().unique().items(Joi.string()).single(),
-    createdDate: getRangeFilter(Joi.string().isoDate(), true),
+    createdDate: getRangeFilter(Joi.string().isoDate()),
     type: Joi.array().unique().items(Joi.string()).single(),
     objectType: Joi.array().unique().items(Joi.string()).single(),
     objectId: Joi.array().unique().items(Joi.string()).single(),

--- a/src/versions/validation/workflow.js
+++ b/src/versions/validation/workflow.js
@@ -76,7 +76,7 @@ schemas['2020-08-10'].getLogsHistory = {
 
     // filters
     id: Joi.array().unique().items(Joi.string()).single(),
-    createdDate: getRangeFilter(Joi.string().isoDate(), true),
+    createdDate: getRangeFilter(Joi.string().isoDate()),
     workflowId: Joi.array().unique().items(Joi.string()).single(),
     eventId: Joi.array().unique().items(Joi.string()).single(),
     runId: Joi.array().unique().items(Joi.string()).single(),


### PR DESCRIPTION
No more (`lt` and `lte`) or (`gt` and `gte`)
provided at the same time