### PR TITLE
fix!: some issues on list filters

### DIFF
--- a/plugins/rating/test/rating.spec.js
+++ b/plugins/rating/test/rating.spec.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 
 const test = require('ava')
 const request = require('supertest')
+const _ = require('lodash')
 
 const {
   testTools: { lifecycle, auth, util }
@@ -17,6 +18,8 @@ const {
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
   checkCursorPaginatedStatsObject,
+
+  checkFilters,
 } = util
 
 test.before(async t => {
@@ -198,6 +201,79 @@ test('gets aggregated rating stats with multiple labels', async (t) => {
   checkStatObject(results[0]['main:pricing'])
 })
 
+// use serial because no changes must be made during the check
+test.serial('check history filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'rating:stats:all',
+      'rating:list:all',
+    ]
+  })
+
+  const groupBys = [
+    'authorId', // document first-level property
+    'assetId', // document data sub-property
+  ]
+
+  for (const groupBy of groupBys) {
+    const { body: { results } } = await request(t.context.serverUrl)
+      .get('/ratings?nbResultsPerPage=100')
+      .set(authorizationHeaders)
+      .expect(200)
+
+    const resultsByGroupBy = _.groupBy(results, groupBy)
+
+    const customExactValueCheck = _.curry((prop, obj, value) => {
+      let filteredResults = resultsByGroupBy[obj[groupBy]] || []
+      filteredResults = filteredResults.filter(r => r[prop] === value)
+      return filteredResults.length === obj.count
+    })
+
+    const customArrayValuesCheck = _.curry((prop, obj, values) => {
+      let filteredResults = resultsByGroupBy[obj[groupBy]] || []
+      filteredResults = filteredResults.filter(r => values.includes(r[prop]))
+      return filteredResults.length === obj.count
+    })
+
+    await checkFilters({
+      t,
+      endpointUrl: `/ratings/stats?groupBy=${groupBy}`,
+      fetchEndpointUrl: '/ratings',
+      authorizationHeaders,
+      checkPaginationObject: checkCursorPaginatedListObject,
+
+      filters: [
+        {
+          prop: 'authorId',
+          isArrayFilter: true,
+          customCheck: customArrayValuesCheck('authorId'),
+        },
+        {
+          prop: 'targetId',
+          isArrayFilter: true,
+          customCheck: customArrayValuesCheck('targetId'),
+        },
+        {
+          prop: 'assetId',
+          // isArrayFilter: true,
+          customCheck: customExactValueCheck('assetId'),
+        },
+        {
+          prop: 'transactionId',
+          // isArrayFilter: true,
+          customCheck: customExactValueCheck('transactionId'),
+        },
+        {
+          prop: 'label',
+          // multiple labels filter on stats are tested on other tests
+          customCheck: customExactValueCheck('label'),
+        },
+      ],
+    })
+  }
+})
+
 // need serial to ensure there is no insertion/deletion during pagination scenario
 test.serial('lists ratings with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['rating:list:all'] })
@@ -219,6 +295,43 @@ test('lists ratings with id filter', async (t) => {
 
   checkCursorPaginatedListObject(t, obj)
   t.is(obj.results.length, 1)
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['rating:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/ratings',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'authorId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'targetId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'assetId',
+      },
+      {
+        prop: 'transactionId',
+      },
+      {
+        prop: 'label',
+        isArrayFilter: true,
+      },
+    ],
+  })
 })
 
 test('lists ratings with advanced filter', async (t) => {

--- a/plugins/rating/test/rating.spec.js
+++ b/plugins/rating/test/rating.spec.js
@@ -246,13 +246,11 @@ test.serial('check history filters', async (t) => {
       filters: [
         {
           prop: 'authorId',
-          isArrayFilter: true,
           customExactValueFilterCheck: customExactValueCheck('authorId'),
           customArrayFilterCheck: customArrayValuesCheck('authorId'),
         },
         {
           prop: 'targetId',
-          isArrayFilter: true,
           customExactValueFilterCheck: customExactValueCheck('targetId'),
           customArrayFilterCheck: customArrayValuesCheck('targetId'),
         },

--- a/plugins/rating/test/rating.spec.js
+++ b/plugins/rating/test/rating.spec.js
@@ -247,27 +247,27 @@ test.serial('check history filters', async (t) => {
         {
           prop: 'authorId',
           isArrayFilter: true,
-          customCheck: customArrayValuesCheck('authorId'),
+          customExactValueFilterCheck: customExactValueCheck('authorId'),
+          customArrayFilterCheck: customArrayValuesCheck('authorId'),
         },
         {
           prop: 'targetId',
           isArrayFilter: true,
-          customCheck: customArrayValuesCheck('targetId'),
+          customExactValueFilterCheck: customExactValueCheck('targetId'),
+          customArrayFilterCheck: customArrayValuesCheck('targetId'),
         },
         {
           prop: 'assetId',
-          // isArrayFilter: true,
-          customCheck: customExactValueCheck('assetId'),
+          customExactValueFilterCheck: customExactValueCheck('assetId'),
         },
         {
           prop: 'transactionId',
-          // isArrayFilter: true,
-          customCheck: customExactValueCheck('transactionId'),
+          customExactValueFilterCheck: customExactValueCheck('transactionId'),
         },
         {
           prop: 'label',
           // multiple labels filter on stats are tested on other tests
-          customCheck: customExactValueCheck('label'),
+          customExactValueFilterCheck: customExactValueCheck('label'),
         },
       ],
     })

--- a/plugins/rating/versions/validation/rating.js
+++ b/plugins/rating/versions/validation/rating.js
@@ -54,8 +54,8 @@ module.exports = function createValidation (deps) {
       // filters
       authorId: getArrayFilter(Joi.string()),
       targetId: getArrayFilter(Joi.string()),
-      assetId: getArrayFilter(Joi.string()),
-      transactionId: getArrayFilter(Joi.string()),
+      assetId: Joi.string(),
+      transactionId: Joi.string(),
       label: [multipleLabelsWithWildcardSchema, Joi.array().unique().items(labelWithWildcardSchema)]
     })
   }
@@ -73,8 +73,8 @@ module.exports = function createValidation (deps) {
       id: getArrayFilter(Joi.string()),
       authorId: getArrayFilter(Joi.string()),
       targetId: getArrayFilter(Joi.string()),
-      assetId: getArrayFilter(Joi.string()),
-      transactionId: getArrayFilter(Joi.string()),
+      assetId: Joi.string(),
+      transactionId: Joi.string(),
       label: [multipleLabelsWithWildcardSchema, Joi.array().unique().items(labelWithWildcardSchema)]
     })
   }

--- a/plugins/rating/versions/validation/rating.js
+++ b/plugins/rating/versions/validation/rating.js
@@ -15,7 +15,7 @@ const orderByFields = [
 module.exports = function createValidation (deps) {
   const {
     utils: {
-      validation: { objectIdParamsSchema, replaceOffsetWithCursorPagination },
+      validation: { objectIdParamsSchema, replaceOffsetWithCursorPagination, getArrayFilter },
       pagination: { DEFAULT_NB_RESULTS_PER_PAGE }
     }
   } = deps
@@ -52,10 +52,10 @@ module.exports = function createValidation (deps) {
       computeRanking: Joi.boolean(),
 
       // filters
-      authorId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      targetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      assetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      transactionId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+      authorId: getArrayFilter(Joi.string()),
+      targetId: getArrayFilter(Joi.string()),
+      assetId: getArrayFilter(Joi.string()),
+      transactionId: getArrayFilter(Joi.string()),
       label: [multipleLabelsWithWildcardSchema, Joi.array().unique().items(labelWithWildcardSchema)]
     })
   }
@@ -70,11 +70,11 @@ module.exports = function createValidation (deps) {
       nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
       // filters
-      id: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      authorId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      targetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      assetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      transactionId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+      id: getArrayFilter(Joi.string()),
+      authorId: getArrayFilter(Joi.string()),
+      targetId: getArrayFilter(Joi.string()),
+      assetId: getArrayFilter(Joi.string()),
+      transactionId: getArrayFilter(Joi.string()),
       label: [multipleLabelsWithWildcardSchema, Joi.array().unique().items(labelWithWildcardSchema)]
     })
   }

--- a/plugins/saved-search/versions/validation/savedSearch.js
+++ b/plugins/saved-search/versions/validation/savedSearch.js
@@ -9,7 +9,7 @@ const orderByFields = [
 module.exports = function createValidation (deps) {
   const {
     utils: {
-      validation: { objectIdParamsSchema, replaceOffsetWithCursorPagination },
+      validation: { objectIdParamsSchema, replaceOffsetWithCursorPagination, getArrayFilter },
       pagination: { DEFAULT_NB_RESULTS_PER_PAGE }
     }
   } = deps
@@ -39,8 +39,8 @@ module.exports = function createValidation (deps) {
       nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
       // filters
-      id: [Joi.string(), Joi.array().unique().items(Joi.string())],
-      userId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+      id: getArrayFilter(Joi.string()),
+      userId: getArrayFilter(Joi.string()),
       active: Joi.boolean()
     })
   }

--- a/src/util/listQueryBuilder.js
+++ b/src/util/listQueryBuilder.js
@@ -116,6 +116,8 @@ function addFiltersToQueryBuilder (queryBuilder, filters, transformedValues) {
           throw createError(400, `${key} value cannot be lower than ${minValue}`)
         }
 
+        const isSingleValue = !_.isPlainObject(transformedValue)
+
         // throw if the `minValue` option is provided
         // and the provided range value doesn't meet this condition
         // otherwise if the provided range value is an object but properties `gt` and `gte` aren't present
@@ -124,23 +126,26 @@ function addFiltersToQueryBuilder (queryBuilder, filters, transformedValues) {
         if (!_.isUndefined(minRangeValue)) {
           if (minRangeValue < minValue) throwMinValueError()
         } else {
-          const isSingleValue = !_.isPlainObject(transformedValue)
           if (!isSingleValue && _.isUndefined(transformedValue.gt) && _.isUndefined(transformedValue.gte)) {
             transformedValue.gte = minValue
           }
         }
 
-        if (transformedValue.lt) {
-          queryBuilder.where(dbField, '<', transformedValue.lt)
-        }
-        if (transformedValue.lte) {
-          queryBuilder.where(dbField, '<=', transformedValue.lte)
-        }
-        if (transformedValue.gt) {
-          queryBuilder.where(dbField, '>', transformedValue.gt)
-        }
-        if (transformedValue.gte) {
-          queryBuilder.where(dbField, '>=', transformedValue.gte)
+        if (isSingleValue) {
+          queryBuilder.where(dbField, transformedValue)
+        } else {
+          if (transformedValue.lt) {
+            queryBuilder.where(dbField, '<', transformedValue.lt)
+          }
+          if (transformedValue.lte) {
+            queryBuilder.where(dbField, '<=', transformedValue.lte)
+          }
+          if (transformedValue.gt) {
+            queryBuilder.where(dbField, '>', transformedValue.gt)
+          }
+          if (transformedValue.gte) {
+            queryBuilder.where(dbField, '>=', transformedValue.gte)
+          }
         }
       } else if (query === 'inList') {
         queryBuilder.whereIn(dbField, transformedValue)

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -112,6 +112,13 @@ function getRangeFilter (joiType) {
   )
 }
 
+function getArrayFilter (joiType) {
+  return customJoi.alternatives().try(
+    joiType,
+    Joi.array().unique().items(joiType),
+  )
+}
+
 const idsSchema = customJoi.array().unique().items(customJoi.string()).single()
 
 const locationSchema = customJoi.object().unknown().keys({
@@ -176,5 +183,6 @@ module.exports = {
   objectIdParamsSchema,
   searchSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 }

--- a/src/versions/validation/apiKey.js
+++ b/src/versions/validation/apiKey.js
@@ -4,6 +4,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -68,7 +69,7 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
     updatedDate: getRangeFilter(Joi.string().isoDate()),
     type: typeSchema,

--- a/src/versions/validation/asset.js
+++ b/src/versions/validation/asset.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -54,12 +55,12 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
     updatedDate: getRangeFilter(Joi.string().isoDate()),
-    ownerId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    categoryId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    assetTypeId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    ownerId: getArrayFilter(Joi.string()),
+    categoryId: getArrayFilter(Joi.string()),
+    assetTypeId: getArrayFilter(Joi.string()),
     validated: Joi.boolean(),
     active: Joi.boolean(),
     quantity: getRangeFilter(Joi.number().integer().min(0)),

--- a/src/versions/validation/assetType.js
+++ b/src/versions/validation/assetType.js
@@ -1,4 +1,4 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter, getArrayFilter } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 const { allowedTimeUnits } = require('../../util/time')
 
@@ -40,7 +40,7 @@ schemas['2020-08-10'].list = {
       endingBefore: Joi.string(),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
       updatedDate: getRangeFilter(Joi.string().isoDate()),
       isDefault: Joi.boolean(),

--- a/src/versions/validation/category.js
+++ b/src/versions/validation/category.js
@@ -1,4 +1,4 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter, getArrayFilter } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -25,10 +25,10 @@ schemas['2020-08-10'].list = {
       endingBefore: Joi.string(),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
       updatedDate: getRangeFilter(Joi.string().isoDate()),
-      parentId: Joi.array().unique().items(Joi.string()).single(),
+      parentId: getArrayFilter(Joi.string()),
     })
     .oxor('startingAfter', 'endingBefore')
 }

--- a/src/versions/validation/customAttribute.js
+++ b/src/versions/validation/customAttribute.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   replaceOffsetWithCursorPagination,
+  getArrayFilter,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
@@ -44,7 +45,7 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())]
+    id: getArrayFilter(Joi.string())
   })
 }
 schemas['2019-05-20'].read = {

--- a/src/versions/validation/document.js
+++ b/src/versions/validation/document.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   replaceOffsetWithCursorPagination,
+  getArrayFilter,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
@@ -57,8 +58,8 @@ schemas['2019-05-20'].getStats = {
     // filters
     type: Joi.string().required(),
     label: [multipleLabelsWithWildcardSchema, Joi.array().unique().items(labelWithWildcardSchema)],
-    authorId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    targetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    authorId: getArrayFilter(Joi.string()),
+    targetId: getArrayFilter(Joi.string()),
     data: Joi.object().unknown()
   }).required()
 }
@@ -73,11 +74,11 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     type: Joi.string().required(),
     label: [multipleLabelsWithWildcardSchema, Joi.array().unique().items(labelWithWildcardSchema)],
-    authorId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    targetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    authorId: getArrayFilter(Joi.string()),
+    targetId: getArrayFilter(Joi.string()),
     data: Joi.object().unknown()
   }).required()
 }

--- a/src/versions/validation/entry.js
+++ b/src/versions/validation/entry.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   replaceOffsetWithCursorPagination,
+  getArrayFilter,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
@@ -37,11 +38,11 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
 
-    collection: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    locale: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    name: [Joi.string(), Joi.array().unique().items(Joi.string())]
+    collection: getArrayFilter(Joi.string()),
+    locale: getArrayFilter(Joi.string()),
+    name: getArrayFilter(Joi.string())
   }).required()
 }
 schemas['2019-05-20'].read = {

--- a/src/versions/validation/event.js
+++ b/src/versions/validation/event.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -61,13 +62,13 @@ schemas['2020-08-10'].getHistory = {
     groupBy: Joi.string().valid('hour', 'day', 'month').required(),
 
     // filters
-    id: Joi.array().unique().items(Joi.string()).single(),
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
-    type: Joi.array().unique().items(Joi.string()).single(),
-    objectType: Joi.array().unique().items(Joi.string()).single(),
-    objectId: Joi.array().unique().items(Joi.string()).single(),
+    type: getArrayFilter(Joi.string()),
+    objectType: getArrayFilter(Joi.string()),
+    objectId: getArrayFilter(Joi.string()),
     emitter: Joi.string().valid('core', 'custom', 'task'),
-    emitterId: Joi.array().unique().items(Joi.string()).single()
+    emitterId: getArrayFilter(Joi.string())
   })
 }
 schemas['2020-08-10'].list = () => ({
@@ -98,13 +99,13 @@ schemas['2019-05-20'].getStats = {
     avgPrecision: Joi.number().integer().min(0).default(2),
 
     // filters
-    id: Joi.array().unique().items(Joi.string()).single(),
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
-    type: Joi.array().unique().items(Joi.string()).single(),
-    objectType: Joi.array().unique().items(Joi.string()).single(),
-    objectId: Joi.array().unique().items(Joi.string()).single(),
+    type: getArrayFilter(Joi.string()),
+    objectType: getArrayFilter(Joi.string()),
+    objectId: getArrayFilter(Joi.string()),
     emitter: Joi.string().valid('core', 'custom', 'task'),
-    emitterId: Joi.array().unique().items(Joi.string()).single(),
+    emitterId: getArrayFilter(Joi.string()),
     object: Joi.object().unknown(),
     metadata: Joi.object().unknown()
   })
@@ -121,13 +122,13 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
-    type: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    objectType: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    objectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    type: getArrayFilter(Joi.string()),
+    objectType: getArrayFilter(Joi.string()),
+    objectId: getArrayFilter(Joi.string()),
     emitter: Joi.string().valid('core', 'custom', 'task'),
-    emitterId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    emitterId: getArrayFilter(Joi.string()),
     object: Joi.object().unknown(),
     metadata: Joi.object().unknown()
   })

--- a/src/versions/validation/message.js
+++ b/src/versions/validation/message.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -36,7 +37,7 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
     updatedDate: getRangeFilter(Joi.string().isoDate()),
     userId: Joi.string(),

--- a/src/versions/validation/order.js
+++ b/src/versions/validation/order.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   replaceOffsetWithCursorPagination,
+  getArrayFilter,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
@@ -80,8 +81,8 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    payerId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
+    payerId: getArrayFilter(Joi.string()),
     receiverId: Joi.string(),
     transactionId: Joi.string()
   })

--- a/src/versions/validation/role.js
+++ b/src/versions/validation/role.js
@@ -1,4 +1,4 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter, getArrayFilter } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
 const orderByFields = [
@@ -25,7 +25,7 @@ schemas['2020-08-10'].list = {
       endingBefore: Joi.string(),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
       updatedDate: getRangeFilter(Joi.string().isoDate()),
     })

--- a/src/versions/validation/task.js
+++ b/src/versions/validation/task.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -49,11 +50,11 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
     updatedDate: getRangeFilter(Joi.string().isoDate()),
-    eventType: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    eventObjectId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    eventType: getArrayFilter(Joi.string()),
+    eventObjectId: getArrayFilter(Joi.string()),
     active: Joi.boolean()
   })
 }

--- a/src/versions/validation/transaction.js
+++ b/src/versions/validation/transaction.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -58,13 +59,13 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
     updatedDate: getRangeFilter(Joi.string().isoDate()),
-    assetId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    assetTypeId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    ownerId: [Joi.string(), Joi.array().unique().items(Joi.string())],
-    takerId: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    assetId: getArrayFilter(Joi.string()),
+    assetTypeId: getArrayFilter(Joi.string()),
+    ownerId: getArrayFilter(Joi.string()),
+    takerId: getArrayFilter(Joi.string()),
     value: getRangeFilter(Joi.number().min(0)),
     ownerAmount: getRangeFilter(Joi.number().min(0)),
     takerAmount: getRangeFilter(Joi.number().min(0)),

--- a/src/versions/validation/user.js
+++ b/src/versions/validation/user.js
@@ -2,6 +2,7 @@ const {
   Joi,
   objectIdParamsSchema,
   getRangeFilter,
+  getArrayFilter,
   replaceOffsetWithCursorPagination,
 } = require('../../util/validation')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
@@ -75,12 +76,12 @@ schemas['2019-05-20'].list = {
     nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
     // filters
-    id: [Joi.string(), Joi.array().unique().items(Joi.string())],
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
     updatedDate: getRangeFilter(Joi.string().isoDate()),
     query: Joi.string(),
     type: Joi.string().valid('organization', 'user', 'all'),
-    userOrganizationId: [Joi.string(), Joi.array().unique().items(Joi.string())]
+    userOrganizationId: getArrayFilter(Joi.string())
   })
 }
 schemas['2019-05-20'].read = {

--- a/src/versions/validation/webhook.js
+++ b/src/versions/validation/webhook.js
@@ -1,4 +1,4 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter, getArrayFilter } = require('../../util/validation')
 const { apiVersions } = require('../util')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
@@ -30,10 +30,10 @@ schemas['2020-08-10'].list = {
       endingBefore: Joi.string(),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
       updatedDate: getRangeFilter(Joi.string().isoDate()),
-      event: Joi.array().unique().items(Joi.string()).single(),
+      event: getArrayFilter(Joi.string()),
       active: Joi.boolean(),
     })
     .oxor('startingAfter', 'endingBefore')
@@ -52,11 +52,11 @@ schemas['2020-08-10'].listLogs = {
       endingBefore: Joi.string(),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
-      webhookId: Joi.array().unique().items(Joi.string()).single(),
-      eventId: Joi.array().unique().items(Joi.string()).single(),
-      status: Joi.array().unique().items(Joi.string()).single(),
+      webhookId: getArrayFilter(Joi.string()),
+      eventId: getArrayFilter(Joi.string()),
+      status: getArrayFilter(Joi.string()),
     })
     .oxor('startingAfter', 'endingBefore')
 }

--- a/src/versions/validation/workflow.js
+++ b/src/versions/validation/workflow.js
@@ -102,7 +102,6 @@ schemas['2020-08-10'].listLogs = {
       eventId: getArrayFilter(Joi.string()),
       runId: getArrayFilter(Joi.string()),
       type: getArrayFilter(Joi.string()),
-      statusCode: getArrayFilter(Joi.string()),
     })
     .oxor('startingAfter', 'endingBefore')
 }

--- a/src/versions/validation/workflow.js
+++ b/src/versions/validation/workflow.js
@@ -1,4 +1,4 @@
-const { Joi, objectIdParamsSchema, getRangeFilter } = require('../../util/validation')
+const { Joi, objectIdParamsSchema, getRangeFilter, getArrayFilter } = require('../../util/validation')
 const { apiVersions } = require('../util')
 const { DEFAULT_NB_RESULTS_PER_PAGE } = require('../../util/pagination')
 
@@ -52,10 +52,10 @@ schemas['2020-08-10'].list = {
       nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
       updatedDate: getRangeFilter(Joi.string().isoDate()),
-      event: Joi.array().unique().items(Joi.string()).single(),
+      event: getArrayFilter(Joi.string()),
       active: Joi.boolean(),
     })
     .oxor('startingAfter', 'endingBefore')
@@ -75,12 +75,12 @@ schemas['2020-08-10'].getLogsHistory = {
     groupBy: Joi.string().valid('hour', 'day', 'month').required(),
 
     // filters
-    id: Joi.array().unique().items(Joi.string()).single(),
+    id: getArrayFilter(Joi.string()),
     createdDate: getRangeFilter(Joi.string().isoDate()),
-    workflowId: Joi.array().unique().items(Joi.string()).single(),
-    eventId: Joi.array().unique().items(Joi.string()).single(),
-    runId: Joi.array().unique().items(Joi.string()).single(),
-    type: Joi.array().unique().items(Joi.string()).single(),
+    workflowId: getArrayFilter(Joi.string()),
+    eventId: getArrayFilter(Joi.string()),
+    runId: getArrayFilter(Joi.string()),
+    type: getArrayFilter(Joi.string()),
   })
 }
 schemas['2020-08-10'].listLogs = {
@@ -96,13 +96,13 @@ schemas['2020-08-10'].listLogs = {
       nbResultsPerPage: Joi.number().integer().min(1).max(100).default(DEFAULT_NB_RESULTS_PER_PAGE),
 
       // filters
-      id: Joi.array().unique().items(Joi.string()).single(),
+      id: getArrayFilter(Joi.string()),
       createdDate: getRangeFilter(Joi.string().isoDate()),
-      workflowId: Joi.array().unique().items(Joi.string()).single(),
-      eventId: Joi.array().unique().items(Joi.string()).single(),
-      runId: Joi.array().unique().items(Joi.string()).single(),
-      type: Joi.array().unique().items(Joi.string()).single(),
-      statusCode: Joi.array().unique().items(Joi.string()).single(),
+      workflowId: getArrayFilter(Joi.string()),
+      eventId: getArrayFilter(Joi.string()),
+      runId: getArrayFilter(Joi.string()),
+      type: getArrayFilter(Joi.string()),
+      statusCode: getArrayFilter(Joi.string()),
     })
     .oxor('startingAfter', 'endingBefore')
 }

--- a/test/integration/api/apiKey.spec.js
+++ b/test/integration/api/apiKey.spec.js
@@ -14,7 +14,9 @@ const {
   checkCursorPaginatedListObject,
 
   checkOffsetPaginationScenario,
-  checkOffsetPaginatedListObject
+  checkOffsetPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 const { encodeBase64 } = require('../../../src/util/encoding')
 
@@ -40,16 +42,37 @@ test.serial('list api keys with pagination', async (t) => {
   })
 })
 
-test('list api keys with id filter', async (t) => {
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['apiKey:list:all'] })
 
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/api-keys?id=apik_aHZQps1I3b1gJYz2I3a')
-    .set(authorizationHeaders)
-    .expect(200)
+  await checkFilters({
+    t,
+    endpointUrl: '/api-keys',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
 
-  checkCursorPaginatedListObject(t, obj)
-  t.is(obj.results.length, 1)
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'updatedDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'type',
+        customTestValues: ['seck', 'pubk', 'cntk', 'custom'],
+        customCheck: (obj, value) => obj.key.startsWith(value),
+      }
+      // `reveal` are tested in other tests
+    ],
+  })
 })
 
 test('list api keys with api key', async (t) => {

--- a/test/integration/api/apiKey.spec.js
+++ b/test/integration/api/apiKey.spec.js
@@ -68,7 +68,7 @@ test.serial('check list filters', async (t) => {
       {
         prop: 'type',
         customTestValues: ['seck', 'pubk', 'cntk', 'custom'],
-        customCheck: (obj, value) => obj.key.startsWith(value),
+        customExactValueFilterCheck: (obj, value) => obj.key.startsWith(value),
       }
       // `reveal` are tested in other tests
     ],

--- a/test/integration/api/customAttribute.spec.js
+++ b/test/integration/api/customAttribute.spec.js
@@ -15,6 +15,8 @@ const {
 
   checkOffsetPaginationScenario,
   checkOffsetPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 test.before(async (t) => {
@@ -35,16 +37,23 @@ test.serial('list custom attributes with pagination', async (t) => {
   })
 })
 
-test('list custom attributes with id filter', async (t) => {
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['customAttribute:list:all'] })
 
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/custom-attributes?id=attr_WmwQps1I3a1gJYz2I3a')
-    .set(authorizationHeaders)
-    .expect(200)
+  await checkFilters({
+    t,
+    endpointUrl: '/custom-attributes',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
 
-  checkCursorPaginatedListObject(t, obj)
-  t.is(obj.results.length, 1)
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+    ],
+  })
 })
 
 test('finds a custom attribute', async (t) => {

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -14,6 +14,8 @@ const {
   checkCursorPaginatedStatsObject,
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 test.before(async (t) => {
@@ -518,6 +520,70 @@ test('fails to get aggregated stats with non-number field', async (t) => {
   t.true(error.message.includes(`Non-number value was found for field "${field}"`))
 })
 
+// use serial because no changes must be made during the check
+test.serial('check history filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'document:stats:all',
+      'document:list:all',
+    ]
+  })
+
+  const groupBys = [
+    'authorId', // document first-level property
+    'data.director', // document data sub-property
+  ]
+
+  for (const groupBy of groupBys) {
+    const { body: { results } } = await request(t.context.serverUrl)
+      .get('/documents?nbResultsPerPage=100&type=movie')
+      .set(authorizationHeaders)
+      .expect(200)
+
+    const resultsByGroupBy = _.groupBy(results, groupBy)
+
+    const customExactValueCheck = _.curry((prop, obj, value) => {
+      let filteredResults = resultsByGroupBy[obj.groupByValue] || []
+      filteredResults = filteredResults.filter(r => r[prop] === value)
+      return filteredResults.length === obj.count
+    })
+
+    const customArrayValuesCheck = _.curry((prop, obj, values) => {
+      let filteredResults = resultsByGroupBy[obj.groupByValue] || []
+      filteredResults = filteredResults.filter(r => values.includes(r[prop]))
+      return filteredResults.length === obj.count
+    })
+
+    await checkFilters({
+      t,
+      endpointUrl: `/documents/stats?groupBy=${groupBy}&type=movie`,
+      fetchEndpointUrl: '/documents?type=movie',
+      authorizationHeaders,
+      checkPaginationObject: checkCursorPaginatedListObject,
+
+      filters: [
+        {
+          prop: 'authorId',
+          isArrayFilter: true,
+          customCheck: customArrayValuesCheck('authorId'),
+        },
+        {
+          prop: 'targetId',
+          isArrayFilter: true,
+          customCheck: customArrayValuesCheck('targetId'),
+        },
+        {
+          prop: 'label',
+          // multiple labels filter on stats are tested on other tests
+          customCheck: customExactValueCheck('label'),
+        },
+        // `data` is tested in other tests
+      ],
+    })
+  }
+})
+
 // need serial to ensure there is no insertion/deletion during pagination scenario
 test.serial('list documents with pagination', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:list:all'] })
@@ -529,16 +595,36 @@ test.serial('list documents with pagination', async (t) => {
   })
 })
 
-test('list documents with id filter', async (t) => {
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['document:list:all'] })
 
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/documents?type=invoice&id=doc_WWRfQps1I3a1gJYz2I3a')
-    .set(authorizationHeaders)
-    .expect(200)
+  await checkFilters({
+    t,
+    endpointUrl: '/documents?type=invoice',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
 
-  checkCursorPaginatedListObject(t, obj)
-  t.is(obj.results.length, 1)
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'label',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'authorId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'targetId',
+        isArrayFilter: true,
+      },
+      // `data` is tested in other tests
+    ],
+  })
 })
 
 test('list documents with advanced filters', async (t) => {

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -565,13 +565,11 @@ test.serial('check history filters', async (t) => {
       filters: [
         {
           prop: 'authorId',
-          isArrayFilter: true,
           customExactValueFilterCheck: customExactValueCheck('authorId'),
           customArrayFilterCheck: customArrayValuesCheck('authorId'),
         },
         {
           prop: 'targetId',
-          isArrayFilter: true,
           customExactValueFilterCheck: customExactValueCheck('targetId'),
           customArrayFilterCheck: customArrayValuesCheck('targetId'),
         },

--- a/test/integration/api/document.spec.js
+++ b/test/integration/api/document.spec.js
@@ -566,17 +566,19 @@ test.serial('check history filters', async (t) => {
         {
           prop: 'authorId',
           isArrayFilter: true,
-          customCheck: customArrayValuesCheck('authorId'),
+          customExactValueFilterCheck: customExactValueCheck('authorId'),
+          customArrayFilterCheck: customArrayValuesCheck('authorId'),
         },
         {
           prop: 'targetId',
           isArrayFilter: true,
-          customCheck: customArrayValuesCheck('targetId'),
+          customExactValueFilterCheck: customExactValueCheck('targetId'),
+          customArrayFilterCheck: customArrayValuesCheck('targetId'),
         },
         {
           prop: 'label',
           // multiple labels filter on stats are tested on other tests
-          customCheck: customExactValueCheck('label'),
+          customExactValueFilterCheck: customExactValueCheck('label'),
         },
         // `data` is tested in other tests
       ],

--- a/test/integration/api/entry.spec.js
+++ b/test/integration/api/entry.spec.js
@@ -14,6 +14,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 test.before(async t => {
@@ -77,6 +79,37 @@ test('list entries with advanced filters', async (t) => {
   obj3.results.forEach(entry => {
     t.true(['website', 'email'].includes(entry.collection))
     t.true(['home', 'signup'].includes(entry.name))
+  })
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['asset:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/entries',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'collection',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'locale',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'name',
+        isArrayFilter: true,
+      },
+    ],
   })
 })
 

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 
 const test = require('ava')
 const request = require('supertest')
+const _ = require('lodash')
 
 const { before, beforeEach, after } = require('../../lifecycle')
 const { getAccessTokenHeaders } = require('../../auth')
@@ -14,7 +15,11 @@ const {
   checkCursorPaginatedHistoryObject,
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
+
+const { truncateDate } = require('../../../src/util/time')
 
 test.before(async t => {
   await before({ name: 'event' })(t)
@@ -149,6 +154,90 @@ test('get events history with date filter', async (t) => {
     obj,
     groupBy,
     results: events
+  })
+})
+
+// use serial because no changes must be made during the check
+test.serial('check history filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({
+    t,
+    permissions: [
+      'event:stats:all',
+      'event:list:all',
+    ]
+  })
+
+  const { body: { results } } = await request(t.context.serverUrl)
+    .get('/events?nbResultsPerPage=100')
+    .set(authorizationHeaders)
+    .expect(200)
+
+  const customExactValueCheck = _.curry((prop, obj, value) => {
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    filteredResults = filteredResults.filter(r => r[prop] === value)
+    return filteredResults.length === obj.count
+  })
+
+  const customArrayValuesCheck = _.curry((prop, obj, values) => {
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    filteredResults = filteredResults.filter(r => values.includes(r[prop]))
+    return filteredResults.length === obj.count
+  })
+
+  const customRangeValuesCheck = _.curry((prop, obj, rangeValues) => {
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    filteredResults = filteredResults.filter(r => rangeValues.gte <= r[prop] && r[prop] <= rangeValues.lte)
+    return filteredResults.length === obj.count
+  })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/events/history?groupBy=day',
+    fetchEndpointUrl: '/events',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+        customCheck: customArrayValuesCheck('id'),
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+        customCheck: customRangeValuesCheck('createdDate'),
+
+        // the function will check a single value range, which will return no results
+        // triggering an error if this boolean isn't true
+        noResultsExistenceCheck: true,
+      },
+      {
+        prop: 'type',
+        isArrayFilter: true,
+        customCheck: customArrayValuesCheck('type'),
+      },
+      {
+        prop: 'objectType',
+        isArrayFilter: true,
+        customCheck: customArrayValuesCheck('objectType'),
+      },
+      {
+        prop: 'objectId',
+        isArrayFilter: true,
+        customCheck: customArrayValuesCheck('objectId'),
+      },
+      {
+        prop: 'emitter',
+        customTestValues: ['core', 'custom', 'task'],
+        customCheck: customExactValueCheck('emitter'),
+      },
+      {
+        prop: 'emitterId',
+        isArrayFilter: true,
+        customCheck: customArrayValuesCheck('emitterId'),
+      },
+    ],
   })
 })
 
@@ -922,6 +1011,50 @@ test('list events with metadata object filters', async (t) => {
 
   t.is(obj8.results.length, 3)
   obj8.results.forEach(checkAssetEvent)
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['event:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/events',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'type',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'objectType',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'objectId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'emitter',
+        customTestValues: ['core', 'custom', 'task'],
+      },
+      {
+        prop: 'emitterId',
+        isArrayFilter: true,
+      },
+      // `object` and `metadata` are tested in other tests
+    ],
+  })
 })
 
 test('finds an event', async (t) => {

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -203,13 +203,11 @@ test.serial('check history filters', async (t) => {
     filters: [
       {
         prop: 'id',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('id'),
         customArrayFilterCheck: customArrayValuesCheck('id'),
       },
       {
         prop: 'createdDate',
-        isRangeFilter: true,
         customExactValueFilterCheck: customExactValueCheck('createdDate'),
         customRangeFilterCheck: customRangeValuesCheck('createdDate'),
 
@@ -219,19 +217,16 @@ test.serial('check history filters', async (t) => {
       },
       {
         prop: 'type',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('type'),
         customArrayFilterCheck: customArrayValuesCheck('type'),
       },
       {
         prop: 'objectType',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('objectType'),
         customArrayFilterCheck: customArrayValuesCheck('objectType'),
       },
       {
         prop: 'objectId',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('objectId'),
         customArrayFilterCheck: customArrayValuesCheck('objectId'),
       },
@@ -242,7 +237,6 @@ test.serial('check history filters', async (t) => {
       },
       {
         prop: 'emitterId',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('emitterId'),
         customArrayFilterCheck: customArrayValuesCheck('emitterId'),
       },

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -172,22 +172,24 @@ test.serial('check history filters', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
+  const groupBy = 'day'
+
   const customExactValueCheck = _.curry((prop, obj, value) => {
-    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj[groupBy])
     filteredResults = filteredResults.filter(r => r[prop] === value)
     return filteredResults.length === obj.count
   })
 
   const customArrayValuesCheck = _.curry((prop, obj, values) => {
-    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj[groupBy])
     filteredResults = filteredResults.filter(r => values.includes(r[prop]))
     return filteredResults.length === obj.count
   })
 
   const customRangeValuesCheck = _.curry((prop, obj, rangeValues, isWithinRange) => {
-    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj[groupBy])
     filteredResults = filteredResults.filter(r => isWithinRange(
-      prop === 'createdDate' ? obj.day : r[prop],
+      prop === 'createdDate' ? obj[groupBy] : r[prop],
       rangeValues
     ))
     return filteredResults.length === obj.count
@@ -195,7 +197,7 @@ test.serial('check history filters', async (t) => {
 
   await checkFilters({
     t,
-    endpointUrl: '/events/history?groupBy=day',
+    endpointUrl: `/events/history?groupBy=${groupBy}`,
     fetchEndpointUrl: '/events',
     authorizationHeaders,
     checkPaginationObject: checkCursorPaginatedListObject,

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -201,12 +201,14 @@ test.serial('check history filters', async (t) => {
       {
         prop: 'id',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('id'),
+        customExactValueFilterCheck: customExactValueCheck('id'),
+        customArrayFilterCheck: customArrayValuesCheck('id'),
       },
       {
         prop: 'createdDate',
         isRangeFilter: true,
-        customCheck: customRangeValuesCheck('createdDate'),
+        customExactValueFilterCheck: customExactValueCheck('createdDate'),
+        customRangeFilterCheck: customRangeValuesCheck('createdDate'),
 
         // the function will check a single value range, which will return no results
         // triggering an error if this boolean isn't true
@@ -215,27 +217,31 @@ test.serial('check history filters', async (t) => {
       {
         prop: 'type',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('type'),
+        customExactValueFilterCheck: customExactValueCheck('type'),
+        customArrayFilterCheck: customArrayValuesCheck('type'),
       },
       {
         prop: 'objectType',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('objectType'),
+        customExactValueFilterCheck: customExactValueCheck('objectType'),
+        customArrayFilterCheck: customArrayValuesCheck('objectType'),
       },
       {
         prop: 'objectId',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('objectId'),
+        customExactValueFilterCheck: customExactValueCheck('objectId'),
+        customArrayFilterCheck: customArrayValuesCheck('objectId'),
       },
       {
         prop: 'emitter',
         customTestValues: ['core', 'custom', 'task'],
-        customCheck: customExactValueCheck('emitter'),
+        customExactValueFilterCheck: customExactValueCheck('emitter'),
       },
       {
         prop: 'emitterId',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('emitterId'),
+        customExactValueFilterCheck: customExactValueCheck('emitterId'),
+        customArrayFilterCheck: customArrayValuesCheck('emitterId'),
       },
     ],
   })

--- a/test/integration/api/event.spec.js
+++ b/test/integration/api/event.spec.js
@@ -184,9 +184,12 @@ test.serial('check history filters', async (t) => {
     return filteredResults.length === obj.count
   })
 
-  const customRangeValuesCheck = _.curry((prop, obj, rangeValues) => {
+  const customRangeValuesCheck = _.curry((prop, obj, rangeValues, isWithinRange) => {
     let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
-    filteredResults = filteredResults.filter(r => rangeValues.gte <= r[prop] && r[prop] <= rangeValues.lte)
+    filteredResults = filteredResults.filter(r => isWithinRange(
+      prop === 'createdDate' ? obj.day : r[prop],
+      rangeValues
+    ))
     return filteredResults.length === obj.count
   })
 

--- a/test/integration/api/message.spec.js
+++ b/test/integration/api/message.spec.js
@@ -14,6 +14,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 test.before(async t => {
@@ -34,31 +36,48 @@ test.serial('list messages with pagination', async (t) => {
   })
 })
 
-test('list messages with id filter', async (t) => {
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['message:list:all'] })
 
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/messages?id=msg_Vuz9KRs10NK1gAHrp0NK')
-    .set(authorizationHeaders)
-    .expect(200)
+  await checkFilters({
+    t,
+    endpointUrl: '/messages',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
 
-  checkCursorPaginatedListObject(t, obj)
-  t.is(obj.results.length, 1)
-  t.is(obj.results[0].id, 'msg_Vuz9KRs10NK1gAHrp0NK')
-})
-
-test('list messages with advanced filters', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['message:list:all'] })
-
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/messages?senderId=user-external-id')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const checkResultsFn = (t, message) => t.is(message.senderId, 'user-external-id')
-
-  checkCursorPaginatedListObject(t, obj, { checkResultsFn })
-  t.is(obj.results.length, 1)
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'updatedDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'userId',
+        customGetValue: (obj) => obj.receiverId || obj.senderId, // get one of the two values
+        customCheck: (obj, value) => [obj.receiverId, obj.senderId].includes(value)
+      },
+      {
+        prop: 'senderId',
+      },
+      {
+        prop: 'receiverId',
+      },
+      {
+        prop: 'topicId',
+      },
+      {
+        prop: 'conversationId',
+      },
+    ],
+  })
 })
 
 test('cannot list messages if the current user does not belong to the conversation', async (t) => {

--- a/test/integration/api/message.spec.js
+++ b/test/integration/api/message.spec.js
@@ -62,7 +62,7 @@ test.serial('check list filters', async (t) => {
       {
         prop: 'userId',
         customGetValue: (obj) => obj.receiverId || obj.senderId, // get one of the two values
-        customCheck: (obj, value) => [obj.receiverId, obj.senderId].includes(value)
+        customExactValueFilterCheck: (obj, value) => [obj.receiverId, obj.senderId].includes(value)
       },
       {
         prop: 'senderId',

--- a/test/integration/api/order.spec.js
+++ b/test/integration/api/order.spec.js
@@ -15,6 +15,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 test.before(async (t) => {
@@ -207,6 +209,30 @@ test('list orders with advanced filters', async (t) => {
     t.true(order.lines.reduce((memo, line) => {
       return memo || line.transactionId === 'trn_Wm1fQps1I3a1gJYz2I3a'
     }, false))
+  })
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['order:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/orders',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'payerId',
+        isArrayFilter: true,
+      },
+      // `receiverId` and `transactionId` tested in other tests
+    ],
   })
 })
 

--- a/test/integration/api/role.spec.js
+++ b/test/integration/api/role.spec.js
@@ -31,7 +31,7 @@ test.serial('lists roles', async (t) => {
 })
 
 // use serial because no changes must be made during the check
-test.serial('check list filters', async (t) => {
+test.serial.only('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['task:list:all'] })
 
   await checkFilters({

--- a/test/integration/api/role.spec.js
+++ b/test/integration/api/role.spec.js
@@ -31,7 +31,7 @@ test.serial('lists roles', async (t) => {
 })
 
 // use serial because no changes must be made during the check
-test.serial.only('check list filters', async (t) => {
+test.serial('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['task:list:all'] })
 
   await checkFilters({

--- a/test/integration/api/task.spec.js
+++ b/test/integration/api/task.spec.js
@@ -15,6 +15,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 const { getRoundedDate } = require('../../../src/util/time')
@@ -88,6 +90,45 @@ test('list tasks with advanced filters', async (t) => {
     t.true(['ast_2l7fQps1I3a1gJYz2I3a'].includes(task.eventObjectId))
     t.is(task.eventType, 'asset_timeout')
     t.true(task.active)
+  })
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['task:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/tasks',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'updatedDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'eventType',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'eventObjectId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'active',
+        customListValues: [true, false],
+      },
+    ],
   })
 })
 

--- a/test/integration/api/transaction.spec.js
+++ b/test/integration/api/transaction.spec.js
@@ -16,6 +16,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 const { getObjectEvent, testEventMetadata } = require('../../util')
 
@@ -114,38 +116,63 @@ test('list transactions for the current user', async (t) => {
   t.pass()
 })
 
-test('list transactions with id filter', async (t) => {
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
   const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['transaction:list:all'] })
 
-  const { body: obj } = await request(t.context.serverUrl)
-    .get('/transactions?id=trn_a3BfQps1I3a1gJYz2I3a')
-    .set(authorizationHeaders)
-    .expect(200)
+  await checkFilters({
+    t,
+    endpointUrl: '/transactions',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
 
-  checkCursorPaginatedListObject(t, obj)
-  t.is(obj.results.length, 1)
-})
-
-test('list transactions with advanced filters', async (t) => {
-  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['transaction:list:all'] })
-
-  const result1 = await request(t.context.serverUrl)
-    .get('/transactions?ownerId=fd7b4ea9-a899-4dba-b9b0-ef8537a70efe,ff4bf0dd-b1d9-49c9-8c61-3e3baa04181c')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj1 = result1.body
-
-  t.is(obj1.results.length, 4)
-
-  const result2 = await request(t.context.serverUrl)
-    .get('/transactions?takerId[]=fd7b4ea9-a899-4dba-b9b0-ef8537a70efe&assetId=ast_0TYM7rs1OwP1gQRuCOwP')
-    .set(authorizationHeaders)
-    .expect(200)
-
-  const obj2 = result2.body
-
-  t.is(obj2.results.length, 0)
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'updatedDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'assetId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'assetTypeId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'ownerId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'takerId',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'value',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'ownerAmount',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'takerAmount',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'platformAmount',
+        isRangeFilter: true,
+      },
+    ],
+  })
 })
 
 test('list transactions with pricing filters', async (t) => {

--- a/test/integration/api/user.spec.js
+++ b/test/integration/api/user.spec.js
@@ -16,6 +16,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 const { encodeBase64 } = require('../../../src/util/encoding')
@@ -75,6 +77,34 @@ test('list users with id filter', async (t) => {
 
   checkCursorPaginatedListObject(t, obj)
   t.is(obj.results.length, 1)
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['user:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/users',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'updatedDate',
+        isRangeFilter: true,
+      },
+      // `query`, `type` and `userOrganizationId` tested in other tests
+    ],
+  })
 })
 
 test('list users with query filter', async (t) => {

--- a/test/integration/api/workflow.spec.js
+++ b/test/integration/api/workflow.spec.js
@@ -21,6 +21,8 @@ const {
 
   checkCursorPaginationScenario,
   checkCursorPaginatedListObject,
+
+  checkFilters,
 } = require('../../util')
 
 const { encodeBase64 } = require('../../../src/util/encoding')
@@ -126,6 +128,41 @@ test('list workflows with advanced filters', async (t) => {
   }
 
   checkCursorPaginatedListObject(t, obj, { checkResultsFn })
+})
+
+// use serial because no changes must be made during the check
+test.serial('check list filters', async (t) => {
+  const authorizationHeaders = await getAccessTokenHeaders({ t, permissions: ['workflow:list:all'] })
+
+  await checkFilters({
+    t,
+    endpointUrl: '/workflows',
+    authorizationHeaders,
+    checkPaginationObject: checkCursorPaginatedListObject,
+
+    filters: [
+      {
+        prop: 'id',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'createdDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'updatedDate',
+        isRangeFilter: true,
+      },
+      {
+        prop: 'event',
+        isArrayFilter: true,
+      },
+      {
+        prop: 'active',
+        customTestValues: [true, false],
+      },
+    ],
+  })
 })
 
 test('list workflows with custom namespace', async (t) => {

--- a/test/integration/api/workflowLog.spec.js
+++ b/test/integration/api/workflowLog.spec.js
@@ -395,6 +395,12 @@ test.serial('check history filters', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
+  const customExactValueCheck = _.curry((prop, obj, value) => {
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    filteredResults = filteredResults.filter(r => r[prop] === value)
+    return filteredResults.length === obj.count
+  })
+
   const customArrayValuesCheck = _.curry((prop, obj, values) => {
     let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
     filteredResults = filteredResults.filter(r => values.includes(r[prop]))
@@ -418,12 +424,14 @@ test.serial('check history filters', async (t) => {
       {
         prop: 'id',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('id'),
+        customExactValueFilterCheck: customExactValueCheck('id'),
+        customArrayFilterCheck: customArrayValuesCheck('id'),
       },
       {
         prop: 'createdDate',
         isRangeFilter: true,
-        customCheck: customRangeValuesCheck('createdDate'),
+        customExactValueFilterCheck: customExactValueCheck('createdDate'),
+        customArrayFilterCheck: customRangeValuesCheck('createdDate'),
 
         // the function will check a single value range, which will return no results
         // triggering an error if this boolean isn't true
@@ -432,22 +440,26 @@ test.serial('check history filters', async (t) => {
       {
         prop: 'workflowId',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('workflowId'),
+        customExactValueFilterCheck: customExactValueCheck('workflowId'),
+        customArrayFilterCheck: customArrayValuesCheck('workflowId'),
       },
       {
         prop: 'eventId',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('eventId'),
+        customExactValueFilterCheck: customExactValueCheck('eventId'),
+        customArrayFilterCheck: customArrayValuesCheck('eventId'),
       },
       {
         prop: 'runId',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('runId'),
+        customExactValueFilterCheck: customExactValueCheck('runId'),
+        customArrayFilterCheck: customArrayValuesCheck('runId'),
       },
       {
         prop: 'type',
         isArrayFilter: true,
-        customCheck: customArrayValuesCheck('type'),
+        customExactValueFilterCheck: customExactValueCheck('type'),
+        customArrayFilterCheck: customArrayValuesCheck('type'),
       },
     ],
   })

--- a/test/integration/api/workflowLog.spec.js
+++ b/test/integration/api/workflowLog.spec.js
@@ -395,27 +395,29 @@ test.serial('check history filters', async (t) => {
     .set(authorizationHeaders)
     .expect(200)
 
+  const groupBy = 'day'
+
   const customExactValueCheck = _.curry((prop, obj, value) => {
-    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj[groupBy])
     filteredResults = filteredResults.filter(r => r[prop] === value)
     return filteredResults.length === obj.count
   })
 
   const customArrayValuesCheck = _.curry((prop, obj, values) => {
-    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj[groupBy])
     filteredResults = filteredResults.filter(r => values.includes(r[prop]))
     return filteredResults.length === obj.count
   })
 
   const customRangeValuesCheck = _.curry((prop, obj, rangeValues) => {
-    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj.day)
+    let filteredResults = results.filter(r => truncateDate(r.createdDate) === obj[groupBy])
     filteredResults = filteredResults.filter(r => rangeValues.gte <= r[prop] && r[prop] <= rangeValues.lte)
     return filteredResults.length === obj.count
   })
 
   await checkFilters({
     t,
-    endpointUrl: '/workflow-logs/history?groupBy=day',
+    endpointUrl: `/workflow-logs/history?groupBy=${groupBy}`,
     fetchEndpointUrl: '/workflow-logs',
     authorizationHeaders,
     checkPaginationObject: checkCursorPaginatedListObject,

--- a/test/integration/api/workflowLog.spec.js
+++ b/test/integration/api/workflowLog.spec.js
@@ -423,13 +423,11 @@ test.serial('check history filters', async (t) => {
     filters: [
       {
         prop: 'id',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('id'),
         customArrayFilterCheck: customArrayValuesCheck('id'),
       },
       {
         prop: 'createdDate',
-        isRangeFilter: true,
         customExactValueFilterCheck: customExactValueCheck('createdDate'),
         customArrayFilterCheck: customRangeValuesCheck('createdDate'),
 
@@ -439,25 +437,21 @@ test.serial('check history filters', async (t) => {
       },
       {
         prop: 'workflowId',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('workflowId'),
         customArrayFilterCheck: customArrayValuesCheck('workflowId'),
       },
       {
         prop: 'eventId',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('eventId'),
         customArrayFilterCheck: customArrayValuesCheck('eventId'),
       },
       {
         prop: 'runId',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('runId'),
         customArrayFilterCheck: customArrayValuesCheck('runId'),
       },
       {
         prop: 'type',
-        isArrayFilter: true,
         customExactValueFilterCheck: customExactValueCheck('type'),
         customArrayFilterCheck: customArrayValuesCheck('type'),
       },


### PR DESCRIPTION
A test util is implemented to automatically check all filters
specified in a config, with values fetched from
fixtures or manually provided.

Three types of filters are tested:
- exact value filter (`prop=value`)
- array filter (`prop[]=value1&prop[]=value2` or `prop=value1,value2`)
- range filter (`prop[gte]=value1&prop[lte]=value2`)

Some issues detected:
- array filter doesn't work with some endpoints (format: `prop=value1,value2`)
- range filter isn't applied when using single value
- unused filter

BREAKING CHANGE:
Filters `assetId` and `transactionId` from rating stats and list endpoints
don't accept array values anymore.
This is because document `data` filter used internally
to filter those properties doesn't
filter a single value property with an array on its
JSONB column.
Moreover, even if we adapt the `data` filter to accept array values
on some defined properties, it will transform the query into
`data->'assetId' <@ [id1,id2]::jsonb` which isn't indexed by
current GIN index.