### PR TITLE
fix(Docker): Elasticsearch image failed to build

### DIFF
--- a/Dockerfile.elasticsearch
+++ b/Dockerfile.elasticsearch
@@ -1,5 +1,14 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.2
 
-RUN bin/elasticsearch-plugin install analysis-icu
+# Set the plugin(s) version to prevent regression due to updates
+# https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugin-management-custom-url.html
+
+# Moreover, prefer download the plugin(s) manually
+# instead of relying on plugin http install
+# with trusted certificate additional complexity
+COPY assets/elasticsearch/analysis-icu-7.3.2.zip /tmp
+
+RUN bin/elasticsearch-plugin install file:///tmp/analysis-icu-7.3.2.zip \
+  && rm /tmp/analysis-icu-7.3.2.zip
 
 CMD [ "docker-entrypoint.sh" ]


### PR DESCRIPTION
The Elasticsearch plugins' version weren't set,
so there is build regression after plugin updates.

Fixes #646